### PR TITLE
Add entry points to setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ the corresponding command line options are displayed.
 
 #### Calling via command line
 From folder src
-```python -m openbiolink.openBioLink -p WORKING_DIR_PATH [-action] [--options] ...```
+```bash
+openbiolink -p WORKING_DIR_PATH [-action] [--options] ...
+```
 
 **Action: Graph Creation**
 ````

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setuptools.setup(
-    name="openbiolink", 
+    name="openbiolink",
     version="0.1.0",
     author="Anna Breit, Matthias Samwald, Simon Ott, Laura Graf, Asan Agibetov",
     author_email="matthiassamwald@gmail.com",
@@ -12,7 +12,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/OpenBioLink/OpenBioLink",
-    package_dir = {'': 'src'},
+    package_dir={'': 'src'},
     packages=setuptools.find_packages("src"),
     classifiers=[
         "Programming Language :: Python :: 3",
@@ -29,4 +29,9 @@ setuptools.setup(
         'sortedcontainers',
     ],
     python_requires='>=3.6',
+    entry_points={
+        "console_scripts": [
+            "openbiolink = openbiolink.openBioLink:main",
+        ],
+    },
 )

--- a/src/openbiolink/__main__.py
+++ b/src/openbiolink/__main__.py
@@ -1,0 +1,12 @@
+"""Entrypoint module, in case you use `python -m openbiolink`.
+
+Why does this file exist, and why `__main__`? For more info, read:
+
+ - https://www.python.org/dev/peps/pep-0338/
+ - https://docs.python.org/3/using/cmdline.html#cmdoption-m
+"""
+
+from .openBioLink import main
+
+if __name__ == '__main__':
+    main()

--- a/src/openbiolink/openBioLink.py
+++ b/src/openbiolink/openBioLink.py
@@ -1,3 +1,16 @@
+"""Command line interface for OpenBioLink.
+
+Why does this file exist, and why not put this in ``__main__``? You might be tempted to import things from ``__main__``
+later, but that will cause problems--the code will get executed twice:
+
+- When you run ``python3 -m openbiolink`` python will execute``__main__.py`` as a script. That means there won't be any
+  ``openbiolink.__main__`` in ``sys.modules``.
+- When you import __main__ it will get executed again (as a module) because
+  there's no ``openbiolink.__main__`` in ``sys.modules``.
+
+.. seealso:: http://click.pocoo.org/5/setuptools/#setuptools-integration
+"""
+
 import argparse
 import cProfile
 import logging


### PR DESCRIPTION
This PR does two things:

1. Adds entry points to setup.py, such that the script can be run with a vanity CLI utility `openbiolink` rather than `python -m openbiolink.OpenBioLink`
2. Adds a `__main__.py` for anyone who might want to run directly as a python module with `python -m openbiolink` (with boilerplate documentation explaining why this works this way)