### PR TITLE
Reorganize CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ playground*
 /src/openbiolink.egg-info
 /in_files
 /graph_files
+/evaluation

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ __pycache__
 playground*
 /test_venv
 
+/o_files
+/src/openbiolink.egg-info
+/in_files
+/graph_files

--- a/README.md
+++ b/README.md
@@ -103,37 +103,40 @@ openbiolink generate --help
 ```
 
 **Action: Train-Test Split Generation**
- ````
--s
-    --edges Path        Path to edges.csv file (required with action -s
-    --tn_edges Path     Path to true_negatives_edges.csv file (required with action -s)
-    --nodes Path        Path to nodes.csv file (required with action -s)
-    --tts_sep [Sep]     Separator of edge, tn-edge and nodes file (e.g. t=tab, n=newline, 
-                        or any other character) (default=t)
-    --mode rand|time    Mode of train-test-set split, options=[rand, time], (default=rand)
-    --test_frac F       Fraction of test set as float (default= 0.2)
-    --crossval          Multiple train-validation-sets are generated
-    --val F             fraction of validation set as float (default= 0.2) or number of folds as int
-    --tmo_edges Path    Path to edges.csv file of t-minus-one graph (required for --mode time
-    --tmo_tn_edges Path     Path to true_negatives_edges.csv file of t-minus-one graph (required for --mode time)
-    --tmo_nodes Path        Path to nodes.csv file of t-minus-one graph (required for --mode time)
-````
-**Action: Training and Evaluation**
-````
--e
-    --model_cls Cls         class of the model to be trained/evaluated (required with -e)
-    --config Path           Path to the models config file
-    --no_train              No training is being performed, trained model id provided via --trained_model
-    --trained_model Path    Path to trained model (required with --no_train)
-    --no_eval               No evaluation is being performed, only training
-    --test Path             Path to test set file (required with -e)
-    --train Path            Path to trainings set file')
-    --eval_nodes Path       Path to the nodes file (required for ranked triples if no corrupted triples 
-                            file is provided and nodes cannot be taken from graph creation
-    --metrics [Metric]      list of evaluation metrics
-    --ks [K]                k's for hits@k metric (integer list)
-````
 
+To split the default graph using the random scheme, use:
+
+```sh
+openbiolink split rand --edges graph_files/edges.csv --tn-edges graph_files/TN_edges.csv --nodes graph_files/nodes.csv
+```
+
+For a list of arguments, use:
+
+```sh
+openbiolink split rand --help
+```
+
+Splitting can also be done by time with 
+
+```sh
+openbiolink split time
+```
+
+More documentation will be provided later.
+
+**Action: Training and Evaluation**
+
+To train on the split default graph, use:
+
+```shell script
+openbiolink train -m TransE_Pykeen -t train_test_data/train_sample.csv -s train_test_data/test_sample.csv
+```
+
+For a list of arguments, use:
+
+```sh
+openbiolink train --help
+```
 
 # Train-test-split creation
 

--- a/README.md
+++ b/README.md
@@ -84,29 +84,24 @@ the corresponding command line options are displayed.
 
 #### Calling via command line
 From folder src
-```bash
+```sh
 openbiolink -p WORKING_DIR_PATH [-action] [--options] ...
 ```
 
 **Action: Graph Creation**
-````
--g:    
-    --undir         Output-Graph should be undirectional (default = directional)
-    --qual          quality cutoff of the output-graph, options = [hq, mq, lq], (default = None -> all entries are used)
-    --no_interact   Disables interactive mode - existing files will be replaced (default = interactive)
-    --skip          Existing files will be skipped - in combination with --no_interact (default = replace)
-    --no_dl         No download is being performed (e.g. when local data is used)
-    --no_in         No input_files are created (e.g. when local data is used)
-    --no_create     No graph is created (e.g. when only in-files should be created)
-    --out_format [TSV|RDF-N3] [Format] [Sep]       Format of graph output, takes 3 arguments: 
-                                                   - The format of the graph files (Currently TSV or RDF-N3 are supported)
-                                                   - A list of file formats [s= single file, m=multiple files] 
-                                                   - A list of separators (only needed if TSV, e.g. t=tab, n=newline, or any other character)
-                                                   (default= TSV s t)
-    --no_qscore     The output files will contain no scores
-    --dbs [Cls]     custom source databases selection to be used, full class name, options --> see doc
-    --mes [Cls]     custom meta edges selection to be used, full class name, options --> see doc
-````
+
+To generate the default graph (with all edges of all qualifies) in the current directory, use:
+
+```sh
+openbiolink generate
+```
+
+For a list of arguments, use:
+
+```sh
+openbiolink generate --help
+```
+
 **Action: Train-Test Split Generation**
  ````
 -s

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     install_requires=[
+        "click",
         "numpy",
         "pandas>=0.23.4",
         "pykeen==0.0.26",

--- a/src/openbiolink/cli_helper.py
+++ b/src/openbiolink/cli_helper.py
@@ -21,10 +21,10 @@ def create_graph(
     do_download=True,
     do_create_input_files=True,
     do_create_graph=True,
+    output_multi=False,
     quality_type: Optional[QualityType] = None,
     output_format: Optional[str] = None,
-    output_single_sep: Optional[str] = None,
-    output_multisep_sep: Optional[str] = None,
+    output_sep: Optional[str] = None,
 ):
     graphProp.DIRECTED = directed
     graphProp.QUALITY = quality_type
@@ -64,8 +64,8 @@ def create_graph(
     if do_create_graph:
         graph_creator.create_graph(
             format=output_format,
-            one_file_sep=output_single_sep,
-            multi_file_sep=output_multisep_sep,
+            file_sep=output_sep,
+            multi_file=output_multi,
             print_qscore=qscore,
         )
 

--- a/src/openbiolink/cli_helper.py
+++ b/src/openbiolink/cli_helper.py
@@ -1,0 +1,131 @@
+import itertools
+import logging
+import sys
+from typing import List, Optional
+
+from openbiolink import globalConfig, globalConfig as glob, graphProperties as graphProp
+from openbiolink.evaluation.evaluation import Evaluation
+from openbiolink.evaluation.metricTypes import RankMetricType, ThresholdMetricType
+from openbiolink.evaluation.models.modelTypes import ModelTypes
+from openbiolink.graph_creation.graphCreation import GraphCreator
+from openbiolink.graph_creation.types.qualityType import QualityType
+
+
+def create_graph(
+    directed: bool,
+    dbs: List[str],
+    mes: List[str],
+    qscore,
+    skip_existing_files: bool,
+    interactive_mode: bool,
+    do_download=True,
+    do_create_input_files=True,
+    do_create_graph=True,
+    quality_type: Optional[QualityType] = None,
+    output_format: Optional[str] = None,
+    output_single_sep: Optional[str] = None,
+    output_multisep_sep: Optional[str] = None,
+):
+    graphProp.DIRECTED = directed
+    graphProp.QUALITY = quality_type
+    globalConfig.INTERACTIVE_MODE = interactive_mode
+    globalConfig.SKIP_EXISTING_FILES = skip_existing_files
+
+    # todo via enums
+    use_db_metadata_classes = None
+    if dbs:
+        db_module_names = [".".join(y) for y in [x.split(".")[0:-1] for x in dbs]]
+        db_cls_names = [x.split(".")[-1] for x in dbs]
+        use_db_metadata_classes = [
+            getattr(sys.modules[module_name], cls_name) for module_name, cls_name in zip(db_module_names, db_cls_names)
+        ]
+
+    use_edge_metadata_classes = None
+    if mes:
+        db_module_names = [".".join(y) for y in [x.split(".")[0:-1] for x in mes]]
+        db_cls_names = [x.split(".")[-1] for x in mes]
+        use_edge_metadata_classes = [
+            getattr(sys.modules[module_name], cls_name) for module_name, cls_name in zip(db_module_names, db_cls_names)
+        ]
+
+    graph_creator = GraphCreator(
+        folder_path=glob.WORKING_DIR,
+        use_db_metadata_classes=use_db_metadata_classes,
+        use_edge_metadata_classes=use_edge_metadata_classes,
+    )
+
+    logging.info("###### (1) GRAPH CREATION ######")
+    if do_download:
+        print("\n\n############### downloading files #################################")
+        logging.info("## Start downloading files ##")
+        graph_creator.download_db_files()
+
+    if do_create_input_files:
+        print("\n\n############### creating graph input files #################################")
+        logging.info("## Start creating input files ##")
+        graph_creator.create_input_files()
+
+    if do_create_graph:
+        print("\n\n############### creating graph #################################")
+        logging.info("## Start creating graph ##")
+        graph_creator.create_graph(
+            format=output_format,
+            one_file_sep=output_single_sep,
+            multi_file_sep=output_multisep_sep,
+            print_qscore=qscore,
+        )
+
+        # with open(os.path.join(globalConfig.WORKING_DIR, globalConfig.GRAPH_PROP_FILE_NAME), 'w') as f:
+        #    graph_prop_dict  = {x: y for x, y in graphProp.__dict__.items() if not x.startswith('__')}
+        #    for k,v in  graph_prop_dict.items():
+        #        if not type(v)==str:
+        #            graph_prop_dict[k] = str(v)
+        #    json.dump(graph_prop_dict, f, indent=4)
+
+
+def train_and_evaluate(
+    model_cls: str,
+    trained_model,
+    training_set_path,
+    test_set_path,
+    nodes_path,
+    do_training,
+    do_evaluation,
+    metrics=None,
+    ks=None,
+    config=None,
+):
+    model_cls = ModelTypes[model_cls].value
+    if trained_model:  # fixme when model provided, config also has to be
+        model = model_cls()
+        model.kge_model = model_cls.load_model(config)
+        # model.kge_model.load_state_dict(torch.load(trained_model))
+        # testme
+    elif config:
+        model = model_cls(config)
+    else:
+        model = model_cls()
+
+    e = Evaluation(
+        model=model,
+        training_set_path=training_set_path,
+        test_set_path=test_set_path,
+        nodes_path=nodes_path,
+        mappings_avail=bool(trained_model),
+    )
+    # todo doku: mappings have to be in model folder with correct name, or change here
+    if do_training:
+        print("starting training")
+        e.train()
+    if do_evaluation:
+        print("starting evaluation")
+        metrics_to_use = list(
+            itertools.chain(RankMetricType.__members__.values(), ThresholdMetricType.__members__.values(), )
+        )
+        if metrics is not None:
+            metrics_to_use = [x for x in metrics_to_use if x.name in metrics]
+        if ks is None:
+            int_ks = [1, 3, 5, 10]
+        else:
+            int_ks = [int(k) for k in ks]
+        e.evaluate(metrics=metrics_to_use, ks=int_ks)

--- a/src/openbiolink/cli_helper.py
+++ b/src/openbiolink/cli_helper.py
@@ -63,10 +63,7 @@ def create_graph(
 
     if do_create_graph:
         graph_creator.create_graph(
-            format=output_format,
-            file_sep=output_sep,
-            multi_file=output_multi,
-            print_qscore=qscore,
+            format=output_format, file_sep=output_sep, multi_file=output_multi, print_qscore=qscore,
         )
 
 

--- a/src/openbiolink/cli_helper.py
+++ b/src/openbiolink/cli_helper.py
@@ -7,7 +7,7 @@ from openbiolink import globalConfig, globalConfig as glob, graphProperties as g
 from openbiolink.evaluation.evaluation import Evaluation
 from openbiolink.evaluation.metricTypes import RankMetricType, ThresholdMetricType
 from openbiolink.evaluation.models.modelTypes import ModelTypes
-from openbiolink.graph_creation.graphCreation import GraphCreator
+from openbiolink.graph_creation.graphCreation import GraphCreation
 from openbiolink.graph_creation.types.qualityType import QualityType
 
 
@@ -48,7 +48,7 @@ def create_graph(
             getattr(sys.modules[module_name], cls_name) for module_name, cls_name in zip(db_module_names, db_cls_names)
         ]
 
-    graph_creator = GraphCreator(
+    graph_creator = GraphCreation(
         folder_path=glob.WORKING_DIR,
         use_db_metadata_classes=use_db_metadata_classes,
         use_edge_metadata_classes=use_edge_metadata_classes,
@@ -56,31 +56,18 @@ def create_graph(
 
     logging.info("###### (1) GRAPH CREATION ######")
     if do_download:
-        print("\n\n############### downloading files #################################")
-        logging.info("## Start downloading files ##")
         graph_creator.download_db_files()
 
     if do_create_input_files:
-        print("\n\n############### creating graph input files #################################")
-        logging.info("## Start creating input files ##")
         graph_creator.create_input_files()
 
     if do_create_graph:
-        print("\n\n############### creating graph #################################")
-        logging.info("## Start creating graph ##")
         graph_creator.create_graph(
             format=output_format,
             one_file_sep=output_single_sep,
             multi_file_sep=output_multisep_sep,
             print_qscore=qscore,
         )
-
-        # with open(os.path.join(globalConfig.WORKING_DIR, globalConfig.GRAPH_PROP_FILE_NAME), 'w') as f:
-        #    graph_prop_dict  = {x: y for x, y in graphProp.__dict__.items() if not x.startswith('__')}
-        #    for k,v in  graph_prop_dict.items():
-        #        if not type(v)==str:
-        #            graph_prop_dict[k] = str(v)
-        #    json.dump(graph_prop_dict, f, indent=4)
 
 
 def train_and_evaluate(

--- a/src/openbiolink/cli_helper.py
+++ b/src/openbiolink/cli_helper.py
@@ -107,7 +107,7 @@ def train_and_evaluate(
     if do_evaluation:
         print("starting evaluation")
         metrics_to_use = list(
-            itertools.chain(RankMetricType.__members__.values(), ThresholdMetricType.__members__.values(), )
+            itertools.chain(RankMetricType.__members__.values(), ThresholdMetricType.__members__.values())
         )
         if metrics is not None:
             metrics_to_use = [x for x in metrics_to_use if x.name in metrics]

--- a/src/openbiolink/cli_helper.py
+++ b/src/openbiolink/cli_helper.py
@@ -7,7 +7,7 @@ from openbiolink import globalConfig, globalConfig as glob, graphProperties as g
 from openbiolink.evaluation.evaluation import Evaluation
 from openbiolink.evaluation.metricTypes import RankMetricType, ThresholdMetricType
 from openbiolink.evaluation.models.modelTypes import ModelTypes
-from openbiolink.graph_creation.graphCreation import GraphCreation
+from openbiolink.graph_creation.graphCreation import Graph_Creation
 from openbiolink.graph_creation.types.qualityType import QualityType
 
 
@@ -48,7 +48,7 @@ def create_graph(
             getattr(sys.modules[module_name], cls_name) for module_name, cls_name in zip(db_module_names, db_cls_names)
         ]
 
-    graph_creator = GraphCreation(
+    graph_creator = Graph_Creation(
         folder_path=glob.WORKING_DIR,
         use_db_metadata_classes=use_db_metadata_classes,
         use_edge_metadata_classes=use_edge_metadata_classes,

--- a/src/openbiolink/graph_creation/file_writer/fileWriter.py
+++ b/src/openbiolink/graph_creation/file_writer/fileWriter.py
@@ -1,4 +1,4 @@
 class FileWriter:
     @staticmethod
-    def wirte_to_file(data, out_path, sep=";"):
+    def write_to_file(data, out_path, sep=";"):
         data.to_csv(out_path, sep=sep, index=False, header=False)

--- a/src/openbiolink/graph_creation/graphCreation.py
+++ b/src/openbiolink/graph_creation/graphCreation.py
@@ -160,7 +160,9 @@ class GraphCreation:
             nodes_dic, edges_dic, one_file_sep=one_file_sep, multi_file_sep=multi_file_sep, print_qscore=print_qscore
         )
         # create TN edges
-        tn_nodes_dic, tn_edges_dic, tn_namespaces_set = graph_creator.meta_edges_to_graph(self.tn_edge_metadata, tn=True)
+        tn_nodes_dic, tn_edges_dic, tn_namespaces_set = graph_creator.meta_edges_to_graph(
+            self.tn_edge_metadata, tn=True
+        )
         graph_writer.output_graph(
             tn_nodes_dic,
             tn_edges_dic,

--- a/src/openbiolink/graph_creation/graphCreation.py
+++ b/src/openbiolink/graph_creation/graphCreation.py
@@ -161,9 +161,7 @@ class Graph_Creation:
 
         # create graph
         nodes_dic, edges_dic, namespaces_set = graph_creator.meta_edges_to_graph(self.edge_metadata)
-        gw.output_graph(
-            nodes_dic, edges_dic, file_sep=file_sep, multi_file=multi_file, print_qscore=print_qscore
-        )
+        gw.output_graph(nodes_dic, edges_dic, file_sep=file_sep, multi_file=multi_file, print_qscore=print_qscore)
         # create TN edges
         tn_nodes_dic, tn_edges_dic, tn_namespaces_set = graph_creator.meta_edges_to_graph(
             self.tn_edge_metadata, tn=True

--- a/src/openbiolink/graph_creation/graphCreation.py
+++ b/src/openbiolink/graph_creation/graphCreation.py
@@ -146,7 +146,7 @@ class Graph_Creation:
 
     # ----------- create graph ----------
 
-    def create_graph(self, format=None, one_file_sep=None, multi_file_sep=None, print_qscore=True):
+    def create_graph(self, format=None, file_sep=None, multi_file=None, print_qscore=True):
         logging.info("## Start creating graph ##")
         graph_creator = GraphCreator()
         if format is None:
@@ -156,13 +156,13 @@ class Graph_Creation:
         else:
             gw = FORMATS[format.upper()]()
 
-        if one_file_sep is None:
-            one_file_sep = "\t"
+        if file_sep is None:
+            file_sep = "\t"
 
         # create graph
         nodes_dic, edges_dic, namespaces_set = graph_creator.meta_edges_to_graph(self.edge_metadata)
         gw.output_graph(
-            nodes_dic, edges_dic, one_file_sep=one_file_sep, multi_file_sep=multi_file_sep, print_qscore=print_qscore
+            nodes_dic, edges_dic, file_sep=file_sep, multi_file=multi_file, print_qscore=print_qscore
         )
         # create TN edges
         tn_nodes_dic, tn_edges_dic, tn_namespaces_set = graph_creator.meta_edges_to_graph(
@@ -171,8 +171,8 @@ class Graph_Creation:
         gw.output_graph(
             tn_nodes_dic,
             tn_edges_dic,
-            one_file_sep=one_file_sep,
-            multi_file_sep=multi_file_sep,
+            file_sep=file_sep,
+            multi_file=multi_file,
             prefix="TN_",
             print_qscore=print_qscore,
         )
@@ -186,8 +186,8 @@ class Graph_Creation:
         gw.output_graph(
             all_nodes_dic,
             None,
-            one_file_sep=one_file_sep,
-            multi_file_sep=None,
+            file_sep=file_sep,
+            multi_file=False,
             prefix="ALL_",
             print_qscore=False,
             node_edge_list=False,

--- a/src/openbiolink/graph_creation/graphCreation.py
+++ b/src/openbiolink/graph_creation/graphCreation.py
@@ -26,7 +26,7 @@ FORMATS = {
 }
 
 
-class GraphCreation:
+class Graph_Creation:
     def __init__(self, folder_path, use_db_metadata_classes=None, use_edge_metadata_classes=None):
         gcConst.O_FILE_PATH = os.path.join(folder_path, gcConst.O_FILE_FOLDER_NAME)
         gcConst.IN_FILE_PATH = os.path.join(folder_path, gcConst.IN_FILE_FOLDER_NAME)

--- a/src/openbiolink/graph_creation/graphCreator.py
+++ b/src/openbiolink/graph_creation/graphCreator.py
@@ -99,7 +99,9 @@ class GraphCreator:
         nodes_dic = {}
         namespaces_set = set()
         tqdmbuffer = TqdmBuffer() if globConst.GUI_MODE else None
-        for d in tqdm(edge_metadata_list, file=tqdmbuffer):
+        it = tqdm(edge_metadata_list, file=tqdmbuffer, desc='meta edges to graph')
+        for d in it:
+            it.write(f'Converting {d}')
             nodes1, nodes2, edges = self.create_nodes_and_edges(d, tn)
             if str(d.edgeType) in edges_dic:
                 edges_dic[str(d.edgeType)].update(edges)
@@ -195,9 +197,7 @@ class GraphCreator:
         no_cutoff_defined = edge_metadata.cutoff_num is None and edge_metadata.cutoff_txt is None
 
         with open(edge_metadata.edges_file_path, "r", encoding="utf8") as edge_content:
-
             reader = csv.reader(edge_content, delimiter=";")
-
             for row in reader:
                 raw_id1 = row[edge_metadata.colindex1]
                 raw_id2 = row[edge_metadata.colindex2]

--- a/src/openbiolink/graph_creation/graphCreator.py
+++ b/src/openbiolink/graph_creation/graphCreator.py
@@ -99,9 +99,9 @@ class GraphCreator:
         nodes_dic = {}
         namespaces_set = set()
         tqdmbuffer = TqdmBuffer() if globConst.GUI_MODE else None
-        it = tqdm(edge_metadata_list, file=tqdmbuffer, desc='meta edges to graph')
+        it = tqdm(edge_metadata_list, file=tqdmbuffer, desc="meta edges to graph")
         for d in it:
-            it.write(f'Converting {d}')
+            it.write(f"Converting {d}")
             nodes1, nodes2, edges = self.create_nodes_and_edges(d, tn)
             if str(d.edgeType) in edges_dic:
                 edges_dic[str(d.edgeType)].update(edges)

--- a/src/openbiolink/graph_creation/graph_writer/graphRDFWriter.py
+++ b/src/openbiolink/graph_creation/graph_writer/graphRDFWriter.py
@@ -26,8 +26,8 @@ class GraphRDFWriter:
     def output_graph(
         nodes_dic: dict = None,
         edges_dic: dict = None,
-        one_file_sep=None,
-        multi_file_sep=None,
+        file_sep=None,
+        multi_file=None,
         prefix=None,
         print_qscore=True,
         node_edge_list=True,
@@ -35,18 +35,20 @@ class GraphRDFWriter:
         if not prefix:
             prefix = ""
 
-        if one_file_sep is None and multi_file_sep is None:
-            one_file_sep = ","
-        # one file
-        if one_file_sep is not None:
-            GraphRDFWriter().output_graph_in_single_file(
-                prefix=prefix, file_sep=one_file_sep, nodes_dic=nodes_dic, edges_dic=edges_dic, qscore=print_qscore
-            )
+        if file_sep is None:
+            file_sep = ","
+
         # separate files
-        if multi_file_sep is not None:
+        if multi_file:
             GraphRDFWriter().output_graph_in_multi_files(
-                prefix, multi_file_sep, nodes_dic, edges_dic, qscore=print_qscore
+                prefix, file_sep, nodes_dic, edges_dic, qscore=print_qscore
             )
+        # one file
+        else:
+            GraphRDFWriter().output_graph_in_single_file(
+                prefix=prefix, file_sep=file_sep, nodes_dic=nodes_dic, edges_dic=edges_dic, qscore=print_qscore
+            )
+
         # lists of all nodes and metaedges
         if node_edge_list:
             GraphRDFWriter().write_node_and_edge_list(prefix, nodes_dic.keys(), edges_dic.keys())

--- a/src/openbiolink/graph_creation/graph_writer/graphRDFWriter.py
+++ b/src/openbiolink/graph_creation/graph_writer/graphRDFWriter.py
@@ -40,9 +40,7 @@ class GraphRDFWriter:
 
         # separate files
         if multi_file:
-            GraphRDFWriter().output_graph_in_multi_files(
-                prefix, file_sep, nodes_dic, edges_dic, qscore=print_qscore
-            )
+            GraphRDFWriter().output_graph_in_multi_files(prefix, file_sep, nodes_dic, edges_dic, qscore=print_qscore)
         # one file
         else:
             GraphRDFWriter().output_graph_in_single_file(

--- a/src/openbiolink/graph_creation/graph_writer/graphTSVWriter.py
+++ b/src/openbiolink/graph_creation/graph_writer/graphTSVWriter.py
@@ -39,9 +39,7 @@ class GraphTSVWriter:
 
         # separate files
         if multi_file:
-            GraphTSVWriter().output_graph_in_multi_files(
-                prefix, file_sep, nodes_dic, edges_dic, qscore=print_qscore
-            )
+            GraphTSVWriter().output_graph_in_multi_files(prefix, file_sep, nodes_dic, edges_dic, qscore=print_qscore)
         # one file
         else:
             GraphTSVWriter().output_graph_in_single_file(

--- a/src/openbiolink/graph_creation/graph_writer/graphTSVWriter.py
+++ b/src/openbiolink/graph_creation/graph_writer/graphTSVWriter.py
@@ -35,18 +35,19 @@ class GraphTSVWriter:
             prefix = ""
 
         if file_sep is None:
-            one_file_sep = ","
+            file_sep = ","
 
-        # one file
-        if not multi_file:
-            GraphTSVWriter().output_graph_in_single_file(
-                prefix=prefix, file_sep=file_sep, nodes_dic=nodes_dic, edges_dic=edges_dic, qscore=print_qscore
-            )
         # separate files
         if multi_file:
             GraphTSVWriter().output_graph_in_multi_files(
                 prefix, file_sep, nodes_dic, edges_dic, qscore=print_qscore
             )
+        # one file
+        else:
+            GraphTSVWriter().output_graph_in_single_file(
+                prefix=prefix, file_sep=file_sep, nodes_dic=nodes_dic, edges_dic=edges_dic, qscore=print_qscore
+            )
+
         # lists of all nodes and metaedges
         if node_edge_list:
             GraphTSVWriter().write_node_and_edge_list(prefix, nodes_dic.keys(), edges_dic.keys())
@@ -61,7 +62,6 @@ class GraphTSVWriter:
             with open(os.path.join(self.graph_dir_path, prefix + gcConst.NODES_FILE_PREFIX + ".csv"), "w") as out_file:
                 writer = csv.writer(out_file, delimiter=file_sep, lineterminator="\n")
                 for key, value in nodes_dic.items():
-                    print(key)
                     for node in value:
                         writer.writerow(list(node))
         if edges_dic is not None:

--- a/src/openbiolink/graph_creation/graph_writer/graphTSVWriter.py
+++ b/src/openbiolink/graph_creation/graph_writer/graphTSVWriter.py
@@ -25,8 +25,8 @@ class GraphTSVWriter:
     def output_graph(
         nodes_dic: dict = None,
         edges_dic: dict = None,
-        one_file_sep=None,
-        multi_file_sep=None,
+        file_sep=None,
+        multi_file=None,
         prefix=None,
         print_qscore=True,
         node_edge_list=True,
@@ -34,17 +34,18 @@ class GraphTSVWriter:
         if not prefix:
             prefix = ""
 
-        if one_file_sep is None and multi_file_sep is None:
+        if file_sep is None:
             one_file_sep = ","
+
         # one file
-        if one_file_sep is not None:
+        if not multi_file:
             GraphTSVWriter().output_graph_in_single_file(
-                prefix=prefix, file_sep=one_file_sep, nodes_dic=nodes_dic, edges_dic=edges_dic, qscore=print_qscore
+                prefix=prefix, file_sep=file_sep, nodes_dic=nodes_dic, edges_dic=edges_dic, qscore=print_qscore
             )
         # separate files
-        if multi_file_sep is not None:
+        if multi_file:
             GraphTSVWriter().output_graph_in_multi_files(
-                prefix, multi_file_sep, nodes_dic, edges_dic, qscore=print_qscore
+                prefix, file_sep, nodes_dic, edges_dic, qscore=print_qscore
             )
         # lists of all nodes and metaedges
         if node_edge_list:
@@ -60,6 +61,7 @@ class GraphTSVWriter:
             with open(os.path.join(self.graph_dir_path, prefix + gcConst.NODES_FILE_PREFIX + ".csv"), "w") as out_file:
                 writer = csv.writer(out_file, delimiter=file_sep, lineterminator="\n")
                 for key, value in nodes_dic.items():
+                    print(key)
                     for node in value:
                         writer.writerow(list(node))
         if edges_dic is not None:

--- a/src/openbiolink/graph_creation/types/qualityType.py
+++ b/src/openbiolink/graph_creation/types/qualityType.py
@@ -5,3 +5,14 @@ class QualityType(Enum):
     HQ = 0
     MQ = 1
     LQ = 2
+
+    @classmethod
+    def get_quality_type(cls, qual: str) -> "QualityType":
+        if qual == "hq":
+            return cls.HQ
+        elif qual == "mq":
+            return cls.MQ
+        elif qual == "lq":
+            return cls.LQ
+        else:
+            raise ValueError(f"Invalid QualityType: {qual}")

--- a/src/openbiolink/gui/evaluationFrame.py
+++ b/src/openbiolink/gui/evaluationFrame.py
@@ -295,36 +295,40 @@ class EvalFrame(tk.Frame):
                 messagebox.showerror("ERROR", "'Perform evaluation' is chosen, but no evaluation metrics are selected")
                 return
         self.controller.ARGS_LIST_EVAL = []
-        self.controller.ARGS_LIST_EVAL.append("-e")
-        self.controller.ARGS_LIST_EVAL.extend(["--model_cls", str(ModelTypes[self.select_model.get()].name)])
+        self.controller.ARGS_LIST_EVAL.append("train")
+        self.controller.ARGS_LIST_EVAL.extend(["-m", str(ModelTypes[self.select_model.get()].name)])
         if self.config_path.get():
             self.controller.ARGS_LIST_EVAL.extend(["--config", self.config_path.get()])
         if not self.train.get():
-            self.controller.ARGS_LIST_EVAL.append("--no_train")
-            self.controller.ARGS_LIST_EVAL.extend(["--trained_model", self.trained_model_path.get()])
+            self.controller.ARGS_LIST_EVAL.append("--no-train")
+            self.controller.ARGS_LIST_EVAL.extend(["--trained-model", self.trained_model_path.get()])
         else:
-            self.controller.ARGS_LIST_EVAL.extend(["--train", self.train_path.get()])
+            self.controller.ARGS_LIST_EVAL.extend(["--trainining-path", self.train_path.get()])
         if not self.evaluate.get():
-            self.controller.ARGS_LIST_EVAL.append("--no_eval")
+            self.controller.ARGS_LIST_EVAL.append("--no-eval")
         else:
             self.controller.ARGS_LIST_EVAL.extend(["--test", self.test_path.get()])
             ranked_metrics = [x.name for x, y in self.rank_metrics_dict.items() if y.get()]
+            for ranked_metric in ranked_metrics:
+                self.controller.ARGS_LIST_EVAL.extend(["--metrics", ranked_metric])
+
             threshold_metrics = [x.name for x, y in self.threshold_metrics_dict.items() if y.get()]
-            self.controller.ARGS_LIST_EVAL.append("--metrics")
-            self.controller.ARGS_LIST_EVAL.extend(ranked_metrics)
-            self.controller.ARGS_LIST_EVAL.extend(threshold_metrics)
+            for threshold_metric in threshold_metrics:
+                self.controller.ARGS_LIST_EVAL.extend(["--metrics", threshold_metric])
+
             if (
                 RankMetricType.HITS_AT_K in self.rank_metrics_dict.keys()
                 or RankMetricType.HITS_AT_K_UNFILTERED in self.rank_metrics_dict.keys()
             ):
-                self.controller.ARGS_LIST_EVAL.append("--ks")
                 import ast
 
-                self.controller.ARGS_LIST_EVAL.extend([str(x) for x in ast.literal_eval(self.ks.get())])
+                for x in ast.literal_eval(self.ks.get()):
+                    self.controller.ARGS_LIST_EVAL.extend(["--ks", str(x)])
+
             # if metrics
             if self.select_node_corrupted.get() == "nodes path":
-                self.controller.ARGS_LIST_EVAL.extend(["--eval_nodes", self.nodes_or_corr_path.get()])
-            elif self.select_node_corrupted.get() == "corrupted triples path":
-                self.controller.ARGS_LIST_EVAL.extend(["--corrupted", self.nodes_or_corr_path.get()])
+                self.controller.ARGS_LIST_EVAL.extend(["--eval-nodes", self.nodes_or_corr_path.get()])
+            # elif self.select_node_corrupted.get() == "corrupted triples path":
+            #    self.controller.ARGS_LIST_EVAL.extend(["--corrupted", self.nodes_or_corr_path.get()])
 
         self.controller.show_next_frame()

--- a/src/openbiolink/gui/graphCreationFrame.py
+++ b/src/openbiolink/gui/graphCreationFrame.py
@@ -277,7 +277,7 @@ class GraphCreationFrame(tk.Frame):
 
         warning = tk.Label(
             el,
-            text="Warning, currrently only N3 graph creation is supported.\n You can not perform a split or evaluation.",
+            text="Warning, currently only N3 graph creation is supported.\n You can not perform a split or evaluation.",
         )
 
         # packing

--- a/src/openbiolink/gui/graphCreationFrame.py
+++ b/src/openbiolink/gui/graphCreationFrame.py
@@ -317,17 +317,17 @@ class GraphCreationFrame(tk.Frame):
             ):
                 messagebox.showerror("ERROR", "Please provide a separator for desired output file")
                 return
-        self.controller.ARGS_LIST_GRAPH_CREATION.append("-g")
+        self.controller.ARGS_LIST_GRAPH_CREATION.append("generate")
         if self.undir.get():
-            self.controller.ARGS_LIST_GRAPH_CREATION.append("--undir")
-        if not self.qual.get() == "None":
+            self.controller.ARGS_LIST_GRAPH_CREATION.append("--undirected")
+        if self.qual.get() != "None":
             self.controller.ARGS_LIST_GRAPH_CREATION.extend(["--qual", self.qual.get()])
         if not self.download.get():
-            self.controller.ARGS_LIST_GRAPH_CREATION.append("--no_dl")
+            self.controller.ARGS_LIST_GRAPH_CREATION.append("--no-download")
         if not self.create_infiles.get():
-            self.controller.ARGS_LIST_GRAPH_CREATION.append("--no_in")
+            self.controller.ARGS_LIST_GRAPH_CREATION.append("--no-input")
         if not self.create_graph.get():
-            self.controller.ARGS_LIST_GRAPH_CREATION.append("--no_create")
+            self.controller.ARGS_LIST_GRAPH_CREATION.append("--no-create")
         if self.one_output_file.get():
             if self.multi_output_file.get():
                 self.controller.ARGS_LIST_GRAPH_CREATION.extend(
@@ -342,16 +342,12 @@ class GraphCreationFrame(tk.Frame):
                 ["--out_format", self.format.get(), "m", self.multi_sep.get()]
             )
         if self.no_qscore.get():
-            self.controller.ARGS_LIST_GRAPH_CREATION.append("--no_qscore")
+            self.controller.ARGS_LIST_GRAPH_CREATION.append("--no-qscore")
         if self.selected_dbs:
-            self.controller.ARGS_LIST_GRAPH_CREATION.append("--dbs")
-            self.controller.ARGS_LIST_GRAPH_CREATION.extend(
-                [x.__module__ + "." + x.__name__ for x in self.selected_dbs]
-            )
+            for x in self.selected_dbs:
+                self.controller.ARGS_LIST_GRAPH_CREATION.extend(["--dbs", x.__module__ + "." + x.__name__])
         if self.selected_meta_edges:
-            self.controller.ARGS_LIST_GRAPH_CREATION.append("--mes")
-            self.controller.ARGS_LIST_GRAPH_CREATION.extend(
-                [x.__module__ + "." + x.__name__ for x in self.selected_meta_edges]
-            )
+            for x in self.selected_meta_edges:
+                self.controller.ARGS_LIST_GRAPH_CREATION.extend(["--mes", x.__module__ + "." + x.__name__])
 
         self.controller.show_next_frame()

--- a/src/openbiolink/gui/graphCreationFrame.py
+++ b/src/openbiolink/gui/graphCreationFrame.py
@@ -254,7 +254,9 @@ class GraphCreationFrame(tk.Frame):
 
         self.output_file_cardinality = tk.IntVar(value=1)
         single_out_file_box = tk.Radiobutton(el, text="single file", variable=self.output_file_cardinality, value=1)
-        multi_out_file_box = tk.Radiobutton(el, text="multiple files (one/type)", variable=self.output_file_cardinality, value=2)
+        multi_out_file_box = tk.Radiobutton(
+            el, text="multiple files (one/type)", variable=self.output_file_cardinality, value=2
+        )
 
         # seperator of file/s
         self.sep = tk.StringVar(value="t")

--- a/src/openbiolink/gui/graphCreationFrame.py
+++ b/src/openbiolink/gui/graphCreationFrame.py
@@ -318,6 +318,8 @@ class GraphCreationFrame(tk.Frame):
                 messagebox.showerror("ERROR", "Please provide a separator for desired output file")
                 return
         self.controller.ARGS_LIST_GRAPH_CREATION.append("generate")
+        self.controller.ARGS_LIST_GRAPH_CREATION.extend(["--out_format", self.format.get()])
+
         if self.undir.get():
             self.controller.ARGS_LIST_GRAPH_CREATION.append("--undirected")
         if self.qual.get() != "None":
@@ -329,18 +331,9 @@ class GraphCreationFrame(tk.Frame):
         if not self.create_graph.get():
             self.controller.ARGS_LIST_GRAPH_CREATION.append("--no-create")
         if self.one_output_file.get():
-            if self.multi_output_file.get():
-                self.controller.ARGS_LIST_GRAPH_CREATION.extend(
-                    ["--out_format", self.format.get(), "sm", self.single_sep.get() + self.multi_sep.get()]
-                )
-            else:
-                self.controller.ARGS_LIST_GRAPH_CREATION.extend(
-                    ["--out_format", self.format.get(), "s", self.single_sep.get()]
-                )
-        elif self.multi_output_file.get():
-            self.controller.ARGS_LIST_GRAPH_CREATION.extend(
-                ["--out_format", self.format.get(), "m", self.multi_sep.get()]
-            )
+            self.controller.ARGS_LIST_GRAPH_CREATION.extend(["--output-single-sep", self.single_sep.get()])
+        if self.multi_output_file.get():
+            self.controller.ARGS_LIST_GRAPH_CREATION.extend(["--output-multi-sep", self.multi_sep.get()])
         if self.no_qscore.get():
             self.controller.ARGS_LIST_GRAPH_CREATION.append("--no-qscore")
         if self.selected_dbs:

--- a/src/openbiolink/gui/graphCreationFrame.py
+++ b/src/openbiolink/gui/graphCreationFrame.py
@@ -217,17 +217,12 @@ class GraphCreationFrame(tk.Frame):
                 # packing
                 separator1.pack(side="top", fill="x", pady=5, padx=5, anchor="w")
                 single_out_file_box.pack(side="top", padx=5, anchor="w")
-                single_sep_frame.pack(side="top", padx=5, anchor="w")
-                single_sep_label.pack(side="left", padx=5, anchor="w")
-                single_sep_value.pack(side="left", anchor="w")
-                single_sep_info.pack(side="left", anchor="w")
-                separator2.pack(side="top", fill="x", pady=5, padx=5, anchor="w")
                 multi_out_file_box.pack(side="top", padx=5, anchor="w")
-                multi_sep_frame.pack(side="top", padx=5, anchor="w")
-                multi_sep_label.pack(side="left", padx=5, anchor="w")
-                multi_sep_value.pack(side="left", anchor="w")
-                multi_sep_info.pack(side="left", anchor="w")
-                separator3.pack(side="top", fill="x", pady=5, padx=5, anchor="w")
+                separator2.pack(side="top", fill="x", pady=5, padx=5, anchor="w")
+                sep_frame.pack(side="top", padx=5, anchor="w")
+                sep_label.pack(side="left", padx=5, anchor="w")
+                sep_value.pack(side="left", anchor="w")
+                sep_info.pack(side="left", anchor="w")
                 no_qscore_box.pack(side="top", padx=5, anchor="w")
             elif self.format.get() == "RDF-N3":
                 forget_packing()
@@ -237,9 +232,8 @@ class GraphCreationFrame(tk.Frame):
                 warning.pack(side="top", fill="x", pady=5, padx=5, anchor="w")
                 separator1.pack(side="top", fill="x", pady=5, padx=5, anchor="w")
                 single_out_file_box.pack(side="top", padx=5, anchor="w")
-                separator2.pack(side="top", fill="x", pady=5, padx=5, anchor="w")
                 multi_out_file_box.pack(side="top", padx=5, anchor="w")
-                separator3.pack(side="top", fill="x", pady=5, padx=5, anchor="w")
+                separator2.pack(side="top", fill="x", pady=5, padx=5, anchor="w")
                 no_qscore_box.pack(side="top", padx=5, anchor="w")
 
         self.format.trace("w", change_dropdown)
@@ -250,42 +244,31 @@ class GraphCreationFrame(tk.Frame):
             warning.pack_forget()
             separator1.pack_forget()
             single_out_file_box.pack_forget()
-            single_sep_frame.pack_forget()
-            single_sep_label.pack_forget()
-            single_sep_value.pack_forget()
-            single_sep_info.pack_forget()
-            separator2.pack_forget()
             multi_out_file_box.pack_forget()
-            multi_sep_frame.pack_forget()
-            multi_sep_label.pack_forget()
-            multi_sep_value.pack_forget()
-            multi_sep_info.pack_forget()
-            separator3.pack_forget()
+            separator2.pack_forget()
+            sep_frame.pack_forget()
+            sep_label.pack_forget()
+            sep_value.pack_forget()
+            sep_info.pack_forget()
             no_qscore_box.pack_forget()
 
-        # single outputfile
-        self.one_output_file = tk.BooleanVar(value=True)
-        single_out_file_box = tk.Checkbutton(el, text="single file", variable=self.one_output_file)
-        self.single_sep = tk.StringVar(value="t")
-        single_sep_frame = tk.Frame(el)
-        single_sep_label = tk.Label(single_sep_frame, text="separator:")
-        single_sep_info = tk.Label(single_sep_frame, text="(t for tab, n for newline)", font=self.controller.info_font)
-        single_sep_value = tk.Entry(single_sep_frame, textvariable=self.single_sep, width=5)
-        # multiple output files
-        self.multi_output_file = tk.BooleanVar(value=False)
-        multi_out_file_box = tk.Checkbutton(el, text="multiple files (one/type)", variable=self.multi_output_file)
-        multi_sep_frame = tk.Frame(el)
-        self.multi_sep = tk.StringVar(value=None)
-        multi_sep_label = tk.Label(multi_sep_frame, text="separator:")
-        multi_sep_info = tk.Label(multi_sep_frame, text="(t for tab, n for newline)", font=self.controller.info_font)
-        multi_sep_value = tk.Entry(multi_sep_frame, textvariable=self.multi_sep, width=5)
+        self.output_file_cardinality = tk.IntVar(value=1)
+        single_out_file_box = tk.Radiobutton(el, text="single file", variable=self.output_file_cardinality, value=1)
+        multi_out_file_box = tk.Radiobutton(el, text="multiple files (one/type)", variable=self.output_file_cardinality, value=2)
+
+        # seperator of file/s
+        self.sep = tk.StringVar(value="t")
+        sep_frame = tk.Frame(el)
+        sep_label = tk.Label(sep_frame, text="separator:")
+        sep_info = tk.Label(sep_frame, text="(t for tab, n for newline)", font=self.controller.info_font)
+        sep_value = tk.Entry(sep_frame, textvariable=self.sep, width=5)
+
         # qscore
         self.no_qscore = tk.BooleanVar(value=False)
         no_qscore_box = tk.Checkbutton(el, text="without quality score", variable=self.no_qscore)
 
         separator1 = ttk.Separator(el, orient="horizontal")
         separator2 = ttk.Separator(el, orient="horizontal")
-        separator3 = ttk.Separator(el, orient="horizontal")
 
         warning = tk.Label(
             el,
@@ -312,13 +295,11 @@ class GraphCreationFrame(tk.Frame):
     def next_page(self):
         self.controller.ARGS_LIST_GRAPH_CREATION = []
         if self.format == "TSV":
-            if (self.one_output_file.get() and self.single_sep.get() == "") or (
-                self.multi_output_file.get() and self.multi_sep.get() == ""
-            ):
+            if self.sep.get() == "":
                 messagebox.showerror("ERROR", "Please provide a separator for desired output file")
                 return
         self.controller.ARGS_LIST_GRAPH_CREATION.append("generate")
-        self.controller.ARGS_LIST_GRAPH_CREATION.extend(["--out_format", self.format.get()])
+        self.controller.ARGS_LIST_GRAPH_CREATION.extend(["--output-format", self.format.get()])
 
         if self.undir.get():
             self.controller.ARGS_LIST_GRAPH_CREATION.append("--undirected")
@@ -330,10 +311,10 @@ class GraphCreationFrame(tk.Frame):
             self.controller.ARGS_LIST_GRAPH_CREATION.append("--no-input")
         if not self.create_graph.get():
             self.controller.ARGS_LIST_GRAPH_CREATION.append("--no-create")
-        if self.one_output_file.get():
-            self.controller.ARGS_LIST_GRAPH_CREATION.extend(["--output-single-sep", self.single_sep.get()])
-        if self.multi_output_file.get():
-            self.controller.ARGS_LIST_GRAPH_CREATION.extend(["--output-multi-sep", self.multi_sep.get()])
+        if self.output_file_cardinality.get() == 2:
+            self.controller.ARGS_LIST_GRAPH_CREATION.append("--output-multi-file")
+        if self.sep.get():
+            self.controller.ARGS_LIST_GRAPH_CREATION.extend(["--output-sep", self.sep.get()])
         if self.no_qscore.get():
             self.controller.ARGS_LIST_GRAPH_CREATION.append("--no-qscore")
         if self.selected_dbs:

--- a/src/openbiolink/gui/graphCreationFrame.py
+++ b/src/openbiolink/gui/graphCreationFrame.py
@@ -213,7 +213,7 @@ class GraphCreationFrame(tk.Frame):
             fmt = self.format.get()
             if fmt == "TSV":
                 forget_packing()
-                self.single_sep = tk.StringVar(value="t")
+                self.single_sep = tk.StringVar(value=None)
                 self.multi_sep = tk.StringVar(value=None)
                 # packing
                 separator1.pack(side="top", fill="x", pady=5, padx=5, anchor="w")
@@ -262,10 +262,10 @@ class GraphCreationFrame(tk.Frame):
         )
 
         # seperator of file/s
-        self.sep = tk.StringVar(value="t")
+        self.sep = tk.StringVar(value=None)
         sep_frame = tk.Frame(el)
         sep_label = tk.Label(sep_frame, text="separator:")
-        sep_info = tk.Label(sep_frame, text="(t for tab, n for newline)", font=self.controller.info_font)
+        sep_info = tk.Label(sep_frame, text="Defaults to tab.", font=self.controller.info_font)
         sep_value = tk.Entry(sep_frame, textvariable=self.sep, width=5)
 
         # qscore

--- a/src/openbiolink/gui/graphCreationFrame.py
+++ b/src/openbiolink/gui/graphCreationFrame.py
@@ -210,7 +210,8 @@ class GraphCreationFrame(tk.Frame):
         self.format.set("TSV")
 
         def change_dropdown(*args):
-            if self.format.get() == "TSV":
+            fmt = self.format.get()
+            if fmt == "TSV":
                 forget_packing()
                 self.single_sep = tk.StringVar(value="t")
                 self.multi_sep = tk.StringVar(value=None)
@@ -224,7 +225,7 @@ class GraphCreationFrame(tk.Frame):
                 sep_value.pack(side="left", anchor="w")
                 sep_info.pack(side="left", anchor="w")
                 no_qscore_box.pack(side="top", padx=5, anchor="w")
-            elif self.format.get() == "RDF-N3":
+            elif fmt == "RDF-N3":
                 forget_packing()
                 self.single_sep = tk.StringVar(value=None)
                 self.multi_sep = tk.StringVar(value=None)
@@ -235,6 +236,8 @@ class GraphCreationFrame(tk.Frame):
                 multi_out_file_box.pack(side="top", padx=5, anchor="w")
                 separator2.pack(side="top", fill="x", pady=5, padx=5, anchor="w")
                 no_qscore_box.pack(side="top", padx=5, anchor="w")
+            else:
+                raise ValueError(f'Invalid format: {fmt}')
 
         self.format.trace("w", change_dropdown)
         format_selector_label = tk.Label(format_selection, text="Format:")
@@ -301,8 +304,8 @@ class GraphCreationFrame(tk.Frame):
                 messagebox.showerror("ERROR", "Please provide a separator for desired output file")
                 return
         self.controller.ARGS_LIST_GRAPH_CREATION.append("generate")
-        self.controller.ARGS_LIST_GRAPH_CREATION.extend(["--output-format", self.format.get()])
-
+        if self.format.get():
+            self.controller.ARGS_LIST_GRAPH_CREATION.extend(["--output-format", self.format.get()])
         if self.undir.get():
             self.controller.ARGS_LIST_GRAPH_CREATION.append("--undirected")
         if self.qual.get() != "None":

--- a/src/openbiolink/gui/graphCreationFrame.py
+++ b/src/openbiolink/gui/graphCreationFrame.py
@@ -237,7 +237,7 @@ class GraphCreationFrame(tk.Frame):
                 separator2.pack(side="top", fill="x", pady=5, padx=5, anchor="w")
                 no_qscore_box.pack(side="top", padx=5, anchor="w")
             else:
-                raise ValueError(f'Invalid format: {fmt}')
+                raise ValueError(f"Invalid format: {fmt}")
 
         self.format.trace("w", change_dropdown)
         format_selector_label = tk.Label(format_selection, text="Format:")

--- a/src/openbiolink/gui/gui.py
+++ b/src/openbiolink/gui/gui.py
@@ -87,7 +87,8 @@ class BimegGui(tk.Tk):
                 for arg_list in args_lists:
                     openBioLink.main(arg_list)
 
-            args = [self.ARGS_LIST_GRAPH_CREATION, self.ARGS_LIST_TRAIN_TEST_SPLIT, self.ARGS_LIST_EVAL]
+            args = [self.ARGS_LIST_GLOBAL, self.ARGS_LIST_GRAPH_CREATION, self.ARGS_LIST_TRAIN_TEST_SPLIT, self.ARGS_LIST_EVAL]
+            print(args)
             thread = threading.Thread(target=_main, args=args, daemon=True)
             thread.start()
 

--- a/src/openbiolink/gui/gui.py
+++ b/src/openbiolink/gui/gui.py
@@ -88,7 +88,6 @@ class BimegGui(tk.Tk):
                     openBioLink.main(arg_list)
 
             args = [self.ARGS_LIST_GLOBAL, self.ARGS_LIST_GRAPH_CREATION, self.ARGS_LIST_TRAIN_TEST_SPLIT, self.ARGS_LIST_EVAL]
-            print(args)
             thread = threading.Thread(target=_main, args=args, daemon=True)
             thread.start()
 

--- a/src/openbiolink/gui/gui.py
+++ b/src/openbiolink/gui/gui.py
@@ -87,7 +87,11 @@ class BimegGui(tk.Tk):
                 for arg_list in args_lists:
                     openBioLink.main(arg_list)
 
-            args = [self.ARGS_LIST_GLOBAL, self.ARGS_LIST_GRAPH_CREATION, self.ARGS_LIST_TRAIN_TEST_SPLIT, self.ARGS_LIST_EVAL]
+            args = [
+                list(self.ARGS_LIST_GLOBAL) + list(args)
+                for args in (self.ARGS_LIST_GRAPH_CREATION, self.ARGS_LIST_TRAIN_TEST_SPLIT, self.ARGS_LIST_EVAL)
+                if args
+            ]
             thread = threading.Thread(target=_main, args=args, daemon=True)
             thread.start()
 

--- a/src/openbiolink/gui/gui.py
+++ b/src/openbiolink/gui/gui.py
@@ -51,14 +51,6 @@ class BimegGui(tk.Tk):
 
         self.show_frame("StartPage")
 
-    def get_args(self):
-        arg_list = []
-        arg_list.extend(self.ARGS_LIST_GLOBAL)
-        arg_list.extend(self.ARGS_LIST_GRAPH_CREATION)
-        arg_list.extend(self.ARGS_LIST_TRAIN_TEST_SPLIT)
-        arg_list.extend(self.ARGS_LIST_EVAL)
-        return arg_list
-
     def set_selected_frames(self, selected_frames):
         self.selected_frames = selected_frames + self.selected_frames
 
@@ -90,8 +82,13 @@ class BimegGui(tk.Tk):
         """ start script and close gui"""
         if messagebox.askokcancel("Start", "Do you want to start now?"):
             self.show_frame("ConsoleFrame")
-            arg_list = self.get_args()
-            thread = threading.Thread(target=openBioLink.main, args=[arg_list], daemon=True)
+
+            def _main(*args_lists):
+                for arg_list in args_lists:
+                    openBioLink.main(arg_list)
+
+            args = [self.ARGS_LIST_GRAPH_CREATION, self.ARGS_LIST_TRAIN_TEST_SPLIT, self.ARGS_LIST_EVAL]
+            thread = threading.Thread(target=_main, args=args, daemon=True)
             thread.start()
 
             # fixme start detached

--- a/src/openbiolink/gui/splitFrame.py
+++ b/src/openbiolink/gui/splitFrame.py
@@ -230,29 +230,45 @@ class SplitFrame(tk.Frame):
 
     def next_page(self):
         self.controller.ARGS_LIST_TRAIN_TEST_SPLIT = []
-        self.controller.ARGS_LIST_TRAIN_TEST_SPLIT.append("-s")
-        self.controller.ARGS_LIST_TRAIN_TEST_SPLIT.extend(["--edges", self.edge_path.get()])
-        self.controller.ARGS_LIST_TRAIN_TEST_SPLIT.extend(["--tn_edges", self.tn_path.get()])
-        self.controller.ARGS_LIST_TRAIN_TEST_SPLIT.extend(["--nodes", self.nodes_path.get()])
 
-        if self.mode.get() == "time":
+        mode = self.mode.get()
+
+        self.controller.ARGS_LIST_TRAIN_TEST_SPLIT.extend(
+            [
+                "split",
+                mode,
+                "--edges",
+                self.edge_path.get(),
+                "--tn_edges",
+                self.tn_path.get(),
+                "--nodes",
+                self.nodes_path.get(),
+            ]
+        )
+
+        if mode == "time":
             if (self.tmo_edge_path.get() == "") or (self.tmo_tn_path.get() == "") or (self.tmo_nodes_path.get() == ""):
                 messagebox.showerror("ERROR", "Please provide all three t-minus one paths.")
                 return
-            self.controller.ARGS_LIST_TRAIN_TEST_SPLIT.extend(["--mode", "time"])
-            self.controller.ARGS_LIST_TRAIN_TEST_SPLIT.extend(["--tmo_edges", self.tmo_edge_path.get()])
-            self.controller.ARGS_LIST_TRAIN_TEST_SPLIT.extend(["--tmo_tn_edges", self.tmo_tn_path.get()])
-            self.controller.ARGS_LIST_TRAIN_TEST_SPLIT.extend(["--tmo_nodes", self.tmo_nodes_path.get()])
-
-        elif self.mode.get() == "rand":
+            self.controller.ARGS_LIST_TRAIN_TEST_SPLIT.extend(
+                [
+                    "--tmo-edges",
+                    self.tmo_edge_path.get(),
+                    "--tmo-tn-edges",
+                    self.tmo_tn_path.get(),
+                    "--tmo-nodes",
+                    self.tmo_nodes_path.get(),
+                ]
+            )
+        elif mode == "rand":
             if self.test_frac.get() == "":
                 messagebox.showerror("ERROR", "Please provide a test set fraction.")
                 return
-            self.controller.ARGS_LIST_TRAIN_TEST_SPLIT.extend(["--mode", "rand"])
-            self.controller.ARGS_LIST_TRAIN_TEST_SPLIT.extend(["--test_frac", self.test_frac.get()])
+            self.controller.ARGS_LIST_TRAIN_TEST_SPLIT.extend(["--test-frac", self.test_frac.get()])
 
             if self.crossval.get():
-                self.controller.ARGS_LIST_TRAIN_TEST_SPLIT.append("--crossval")  # todo crossval
-                self.controller.ARGS_LIST_TRAIN_TEST_SPLIT.extend(["--val", self.folds.get()])
+                self.controller.ARGS_LIST_TRAIN_TEST_SPLIT.extend(
+                    ["--crossval", "--val", self.folds.get(),]  # todo crossval
+                )
 
         self.controller.show_next_frame()

--- a/src/openbiolink/openBioLink.py
+++ b/src/openbiolink/openBioLink.py
@@ -20,6 +20,7 @@ import click
 from openbiolink import globalConfig as glob
 from openbiolink.cli_helper import create_graph, train_and_evaluate
 from openbiolink.evaluation.models.modelTypes import ModelTypes
+from openbiolink.graph_creation.graphCreation import FORMATS
 from openbiolink.graph_creation.types.qualityType import QualityType
 from openbiolink.train_test_set_creation.trainTestSplitCreation import TrainTestSetCreation
 
@@ -70,6 +71,9 @@ def handle_quality(_, __, qual):
 @click.option("--no-input", is_flag=True, help="No input_files are created (e.g. when local data is used)")
 @click.option("--no-create", is_flag=True, help="No graph is created (e.g. when only in-files should be created)")
 @click.option("--no-qscore", is_flag=True, help="The output files will contain no scores")
+@click.option("--output-format", type=click.Choice(list(FORMATS)), default="TSV", show_default=True)
+@click.option("--output-single-sep")
+@click.option("--output-multi-sep")
 @click.option(
     "--dbs", multiple=True, help="custom source databases selection to be used, full class name, options --> see doc"
 )
@@ -85,6 +89,9 @@ def generate(
     no_input: bool,
     no_create: bool,
     no_qscore: bool,
+    output_format: str,
+    output_single_sep,
+    output_multi_sep,
     dbs,
     mes,
 ):
@@ -105,6 +112,9 @@ def generate(
         do_create_input_files=not no_input,
         do_create_graph=not no_create,
         qscore=not no_qscore,
+        output_format=output_format,
+        output_single_sep=output_single_sep,
+        output_multisep_sep=output_multi_sep,
         dbs=dbs,
         mes=mes,
     )
@@ -167,7 +177,7 @@ def rand(edges, tn_edges, nodes, sep, test_frac, crossval, val):
         sys.exit(-1)
 
     click.secho("Loading data")
-    tts = TrainTestSetCreation(graph_path=edges, tn_graph_path=tn_edges, all_nodes_path=nodes, sep=sep,)
+    tts = TrainTestSetCreation(graph_path=edges, tn_graph_path=tn_edges, all_nodes_path=nodes, sep=sep)
     click.secho("Creating random slice split", fg="blue")
     tts.random_edge_split(val=val, test_frac=test_frac, crossval=crossval)
 

--- a/src/openbiolink/openBioLink.py
+++ b/src/openbiolink/openBioLink.py
@@ -28,7 +28,14 @@ logger = logging.getLogger(__name__)
 
 
 @click.group()
-@click.option("-p", "--directory", default=os.getcwd(), help="the working directory")
+@click.option(
+    "-p",
+    "--directory",
+    default=os.getcwd(),
+    show_default=True,
+    type=click.Path(dir_okay=True, file_okay=False),
+    help="The output directory. Uses current if not given.",
+)
 def main(directory: str):
     """OpenBioLink CLI."""
     glob.WORKING_DIR = directory
@@ -52,21 +59,15 @@ def handle_quality(_, __, qual):
 @click.option(
     "--qual",
     type=click.Choice(["hq", "mq", "lq"]),
-    default="lq",
-    show_default=True,
     callback=handle_quality,
-    help="quality level od the output-graph (default = None -> all entries are used)",
+    help="minimum quality level of the output-graph. If not specified, all entries are used.",
 )
 @click.option(
     "--no-interact",
     is_flag=True,
     help="Disables interactive mode - existing files will be replaced (default = interactive)",
 )
-@click.option(
-    "--skip",
-    is_flag=True,
-    help="Existing files will be skipped - in combination with --no_interact (default = replace)",
-)
+@click.option("--skip", is_flag=True, help="Skip re-downloading existing files.")
 @click.option("--no-download", is_flag=True, help="No download is being performed (e.g. when local data is used)")
 @click.option("--no-input", is_flag=True, help="No input_files are created (e.g. when local data is used)")
 @click.option("--no-create", is_flag=True, help="No graph is created (e.g. when only in-files should be created)")
@@ -78,18 +79,12 @@ def handle_quality(_, __, qual):
     show_default=True,
     help="Format of output files TSV or RDF-N3",
 )
-@click.option(
-    "--output-sep",
-    default="t",
-    show_default=True,
-    help="Seperator used in the output files (t = tab seperated, n = newline, or any other char)",
-)
+@click.option("--output-sep", help="The separator used in the output files. Defaults to tab")
 @click.option(
     "--output-multi-file",
     is_flag=True,
-    default=False,
-    help="Edges and nodes are written to multiple files, instead of"
-    "single files (accordingly grouped by edge type and node type)",
+    help="Edges and nodes are written to multiple files, "
+    "instead of single files (accordingly grouped by edge type and node type)",
 )
 @click.option(
     "--dbs", multiple=True, help="custom source databases selection to be used, full class name, options --> see doc"
@@ -140,7 +135,7 @@ def generate(
 edges_option = click.option("--edges", required=True, help="Path to edges.csv file")
 tn_edges_option = click.option("--tn-edges", required=True, help="Path to true_negatives_edges.csv file")
 nodes_option = click.option("--nodes", required=True, help="Path to nodes.csv file")
-sep_option = click.option("--sep", default="\t", show_default=True, help="Separator of edge, tn-edge, and nodes file")
+sep_option = click.option("--sep", help="Separator of edge, tn-edge, and nodes file")
 
 
 @main.group()

--- a/src/openbiolink/openBioLink.py
+++ b/src/openbiolink/openBioLink.py
@@ -19,6 +19,7 @@ import click
 
 from openbiolink import globalConfig as glob
 from openbiolink.cli_helper import create_graph, train_and_evaluate
+from openbiolink.evaluation.models.modelTypes import ModelTypes
 from openbiolink.graph_creation.types.qualityType import QualityType
 from openbiolink.train_test_set_creation.trainTestSplitCreation import TrainTestSetCreation
 
@@ -172,16 +173,19 @@ def rand(edges, tn_edges, nodes, sep, test_frac, crossval, val):
 
 
 @main.command()
-@click.option("--model-cls", help="class of the model to be trained/evaluated (required with -e)")
+@click.option(
+    "-m",
+    "--model-cls",
+    required=True,
+    type=click.Choice(list(ModelTypes.__members__)),
+    help="class of the model to be trained/evaluated",
+)
 @click.option("--config", help="Path to the model' config file")
 @click.option("--no-train", is_flag=True, help="No training is being performed, trained model id provided via --model")
 @click.option("--trained-model", help="Path to trained model (required with --no-train)")
 @click.option("--no-eval", is_flag=True, help="No evaluation is being performed, only training")
-@click.option("--test", help="Path to test set file (required with -e)")
-@click.option("--train", help="Path to trainings set file")  # (alternative: --cv_folder)')
-@click.option(
-    "--corrupted", help="path to the corrupted triples (required for ranked triples if no nodes file is provided",
-)  # fixme no longer an option
+@click.option("-t", "--testing-path", required=True, help="Path to test set file")
+@click.option("-s", "--training-path", help="Path to trainings set file")  # (alternative: --cv_folder)')
 @click.option(
     "--eval-nodes",
     help="path to the nodes file (required for ranked triples if no corrupted triples file is provided and nodes cannot be taken from graph creation",
@@ -189,14 +193,14 @@ def rand(edges, tn_edges, nodes, sep, test_frac, crossval, val):
 @click.option("--metrics", multiple=True, help="evaluation metrics")
 @click.option("--ks", multiple=True, help="k's for hits@k metric")
 def train(
-    model_cls, trained_model, train, test, eval_nodes, no_train, no_eval, metrics, ks, config,
+    model_cls, trained_model, training_path, testing_path, eval_nodes, no_train, no_eval, metrics, ks, config,
 ):
     """Train and evaluate on a graph."""
     train_and_evaluate(
         model_cls=model_cls,
         trained_model=trained_model,
-        training_set_path=train,
-        test_set_path=test,
+        training_set_path=training_path,
+        test_set_path=testing_path,
         nodes_path=eval_nodes,
         do_training=not no_train,
         do_evaluation=not no_eval,

--- a/src/openbiolink/openBioLink.py
+++ b/src/openbiolink/openBioLink.py
@@ -11,354 +11,199 @@ later, but that will cause problems--the code will get executed twice:
 .. seealso:: http://click.pocoo.org/5/setuptools/#setuptools-integration
 """
 
-import argparse
-import cProfile
 import logging
 import os
 import sys
 
-import openbiolink.graphProperties as graphProp
-from openbiolink import globalConfig, globalConfig as glob
-from openbiolink.evaluation.evaluation import Evaluation
-from openbiolink.evaluation.metricTypes import RankMetricType, ThresholdMetricType
-from openbiolink.evaluation.models.modelTypes import ModelTypes
-from openbiolink.graph_creation.graphCreation import Graph_Creation
+import click
+
+from openbiolink import globalConfig as glob
+from openbiolink.cli_helper import create_graph, train_and_evaluate
 from openbiolink.graph_creation.types.qualityType import QualityType
 from openbiolink.train_test_set_creation.trainTestSplitCreation import TrainTestSetCreation
 
+logger = logging.getLogger(__name__)
 
-def create_graph(args):
-    graphProp.DIRECTED = not args.undir
-    graphProp.QUALITY = args.qual
-    globalConfig.INTERACTIVE_MODE = not args.no_interact
-    globalConfig.SKIP_EXISTING_FILES = args.skip
 
-    use_db_metadata_classes = None
-    use_edge_metadata_classes = None
-    # todo via enums
-    if args.dbs:
-        db_module_names = [".".join(y) for y in [x.split(".")[0:-1] for x in args.dbs]]
-        db_cls_names = [x.split(".")[-1] for x in args.dbs]
-        use_db_metadata_classes = [
-            getattr(sys.modules[module_name], cls_name) for module_name, cls_name in zip(db_module_names, db_cls_names)
-        ]
-    if args.mes:
-        db_module_names = [".".join(y) for y in [x.split(".")[0:-1] for x in args.mes]]
-        db_cls_names = [x.split(".")[-1] for x in args.mes]
-        use_edge_metadata_classes = [
-            getattr(sys.modules[module_name], cls_name) for module_name, cls_name in zip(db_module_names, db_cls_names)
-        ]
+@click.group()
+@click.option("-p", "--directory", default=os.getcwd(), help="the working directory")
+def main(directory: str):
+    """OpenBioLink CLI."""
+    glob.WORKING_DIR = directory
 
-    graph_creator = Graph_Creation(
-        folder_path=glob.WORKING_DIR,
-        use_db_metadata_classes=use_db_metadata_classes,
-        use_edge_metadata_classes=use_edge_metadata_classes,
-    )
 
-    logging.info("###### (1) GRAPH CREATION ######")
-    if not args.no_dl:
-        print("\n\n############### downloading files #################################")
-        logging.info("## Start downloading files ##")
-        graph_creator.download_db_files()
+@main.command()
+def gui():
+    """Run the OpenBioLink GUI."""
+    glob.GUI_MODE = True
+    from openbiolink.gui import gui
 
-    if not args.no_in:
-        print("\n\n############### creating graph input files #################################")
-        logging.info("## Start creating input files ##")
-        graph_creator.create_input_files()
+    gui.start_gui()
 
-    if not args.no_create:
-        print("\n\n############### creating graph #################################")
-        logging.info("## Start creating graph ##")
-        format = "".join(args.out_format[0])
-        single_sep = ""
-        multisep_sep = ""
-        if "s" in args.out_format[1]:
-            if format == "TSV":
-                single_sep = args.out_format[2][args.out_format[1].index("s")]
-                if single_sep == "n" or single_sep == "t":
-                    single_sep = single_sep.replace("n", "\n").replace("t", "\t")
-        else:
-            single_sep = None
-        if "m" in args.out_format[1]:
-            if format == "TSV":
-                multisep_sep = args.out_format[2][args.out_format[1].index("m")]
-                if multisep_sep == "n" or multisep_sep == "t":
-                    multisep_sep = multisep_sep.replace("n", "\n").replace("t", "\t")
-        else:
-            multisep_sep = None
 
-        graph_creator.create_graph(
-            format=format, one_file_sep=single_sep, multi_file_sep=multisep_sep, print_qscore=(not args.no_qscore)
+def handle_quality(_, __, qual):
+    return QualityType.get_quality_type(qual)
+
+
+@main.command()
+@click.option("--undirected", is_flag=True, help="Output-Graph should be undirectional (default = directional)")
+@click.option(
+    "--qual",
+    type=click.Choice(["hq", "mq", "lq"]),
+    default='lq',
+    show_default=True,
+    callback=handle_quality,
+    help="quality level od the output-graph (default = None -> all entries are used)",
+)
+@click.option(
+    "--no-interact",
+    is_flag=True,
+    help="Disables interactive mode - existing files will be replaced (default = interactive)",
+)
+@click.option(
+    "--skip",
+    is_flag=True,
+    help="Existing files will be skipped - in combination with --no_interact (default = replace)",
+)
+@click.option("--no-dl", is_flag=True, help="No download is being performed (e.g. when local data is used)")
+@click.option("--no-in", is_flag=True, help="No input_files are created (e.g. when local data is used)")
+@click.option("--no-create", is_flag=True, help="No graph is created (e.g. when only in-files should be created)")
+@click.option("--no-qscore", is_flag=True, help="The output files will contain no scores")
+@click.option(
+    "--dbs", multiple=True, help="custom source databases selection to be used, full class name, options --> see doc"
+)
+@click.option(
+    "--mes", multiple=True, help="custom meta edges selection to be used, full class name, options --> see doc"
+)
+def generate(
+    undirected: bool,
+    qual: QualityType,
+    no_interact: bool,
+    skip: bool,
+    no_dl: bool,
+    no_in: bool,
+    no_create: bool,
+    no_qscore: bool,
+    dbs,
+    mes,
+):
+    """Generate a graph."""
+    if no_in and not no_dl and not no_create:
+        click.secho(
+            "Graph Creation: downloading graph files and creating the graph without creating in_files is not possible",
+            fg="red",
         )
+        sys.exit(-1)
 
-        # with open(os.path.join(globalConfig.WORKING_DIR, globalConfig.GRAPH_PROP_FILE_NAME), 'w') as f:
-        #    graph_prop_dict  = {x: y for x, y in graphProp.__dict__.items() if not x.startswith('__')}
-        #    for k,v in  graph_prop_dict.items():
-        #        if not type(v)==str:
-        #            graph_prop_dict[k] = str(v)
-        #    json.dump(graph_prop_dict, f, indent=4)
+    create_graph(
+        directed=not undirected,
+        quality_type=qual,
+        interactive_mode=not no_interact,
+        skip_existing_files=skip,
+        do_download=not no_dl,
+        do_create_input_files=not no_in,
+        do_create_graph=not no_create,
+        qscore=not no_qscore,
+        dbs=dbs,
+        mes=mes,
+    )
 
 
-def create_train_test_splits(args):
-    if args.tts_sep == "t":
-        sep = "\t"
-    elif args.tts_sep == "n":
-        sep = "\n"
-    else:
-        sep = args.tts_sep
+edges_option = click.option("--edges", required=True, help="Path to edges.csv file")
+tn_edges_option = click.option("--tn-edges", required=True, help="Path to true_negatives_edges.csv file")
+nodes_option = click.option("--nodes", required=True, help="Path to nodes.csv file")
+sep_option = click.option("--sep", default="\t", show_default=True, help="Separator of edge, tn-edge, and nodes file")
+
+
+@main.group()
+def split():
+    """Split a graph."""
+
+
+@split.command()
+@edges_option
+@tn_edges_option
+@nodes_option
+@sep_option
+def time(edges, tn_edges, nodes, sep):
+    """Split based on time."""
+    tts = TrainTestSetCreation(graph_path=edges, tn_graph_path=tn_edges, all_nodes_path=nodes, sep=sep,)
+
+    click.secho("Creating time slice split", fg="blue")
+    tts.time_slice_split()
+
+
+@split.command()
+@edges_option
+@tn_edges_option
+@nodes_option
+@sep_option
+@click.option("--tmo-edges", required=True, help="Path to edges.csv file of t-minus-one graph")
+@click.option("--tmo-tn-edges", required=True, help="Path to true_negatives_edges.csv file of t-minus-one graph")
+@click.option("--tmo-nodes", required=True, help="Path to nodes.csv file of t-minus-one graph")
+@click.option("--test-frac", type=float, default=0.2, help="Fraction of test set as float (default= 0.2)")
+@click.option("--crossval", is_flag=True, help="Multiple train-validation-sets are generated")
+@click.option(
+    "--val",
+    type=float,
+    default=0.2,
+    help="Fraction of validation set as float (default= 0.2) or number of folds as int",
+)
+def rand(edges, tn_edges, nodes, sep, tmo_edges, tmo_tn_edges, tmo_nodes, test_frac, crossval, val):
+    """Split randomly."""
+    if crossval and (val == 0 or val == 1 or (val > 1 and not float(val).is_integer())):
+        click.secho(
+            "fold entry must be either an int>1 (number of folds) or a float >0 and <1 (validation fraction)", fg="red",
+        )
+        sys.exit(-1)
+
     tts = TrainTestSetCreation(
-        graph_path=args.edges,
-        tn_graph_path=args.tn_edges,
-        all_nodes_path=args.nodes,
+        graph_path=edges,
+        tn_graph_path=tn_edges,
+        all_nodes_path=nodes,
         sep=sep,
-        # meta_edge_triples=args.meta,
-        t_minus_one_graph_path=args.tmo_edges,
-        t_minus_one_tn_graph_path=args.tmo_tn_edges,
-        t_minus_one_nodes_path=args.tmo_nodes,
+        t_minus_one_graph_path=tmo_edges,
+        t_minus_one_tn_graph_path=tmo_tn_edges,
+        t_minus_one_nodes_path=tmo_nodes,
     )
-    if args.mode == "time":
-        print("\n\n############### creating time slice split #################################")
-        logging.info("## Start creating time slice split ##")
-        tts.time_slice_split()
-    elif args.mode == "rand":
-        print("\n\n############### creating random slice split #################################")
-        logging.info("## Start creating random slice split ##")
-        tts.random_edge_split(val=args.val, test_frac=args.test_frac, crossval=args.crossval)
-    # tts.random_edge_split(crossval=False)
+    click.secho("Creating random slice split", fg="blue")
+    tts.random_edge_split(val=val, test_frac=test_frac, crossval=crossval)
 
 
-def train_and_evaluate(args):
-    model_cls = ModelTypes[args.model_cls].value
-    if args.trained_model:  # fixme when model provided, config also has to be
-        if args.config:
-            config = args.config
-            # model = model_cls(args.config)
-        else:
-            config = None
-        model = model_cls()
-        model.kge_model = model_cls.load_model(config)
-        # model.kge_model.load_state_dict(torch.load(args.trained_model))
-        # testme
-    elif args.config:
-        model = model_cls(args.config)
-    else:
-        model = model_cls()
-    e = Evaluation(
-        model=model,
-        training_set_path=args.train,
-        test_set_path=args.test,
-        nodes_path=args.eval_nodes,
-        mappings_avail=bool(args.trained_model),
+@main.command()
+@click.option("--model-cls", help="class of the model to be trained/evaluated (required with -e)")
+@click.option("--config", help="Path to the model' config file")
+@click.option("--no-train", is_flag=True, help="No training is being performed, trained model id provided via --model")
+@click.option("--trained-model", help="Path to trained model (required with --no-train)")
+@click.option("--no-eval", is_flag=True, help="No evaluation is being performed, only training")
+@click.option("--test", help="Path to test set file (required with -e)")
+@click.option("--train", help="Path to trainings set file")  # (alternative: --cv_folder)')
+@click.option(
+    "--corrupted", help="path to the corrupted triples (required for ranked triples if no nodes file is provided",
+)  # fixme no longer an option
+@click.option(
+    "--eval-nodes",
+    help="path to the nodes file (required for ranked triples if no corrupted triples file is provided and nodes cannot be taken from graph creation",
+)
+@click.option("--metrics", multiple=True, help="evaluation metrics")
+@click.option("--ks", multiple=True, help="k's for hits@k metric")
+def train(
+    model_cls, trained_model, train, test, eval_nodes, no_train, no_eval, metrics, ks, config,
+):
+    """Train and evaluate on a graph."""
+    train_and_evaluate(
+        model_cls=model_cls,
+        trained_model=trained_model,
+        training_set_path=train,
+        test_set_path=test,
+        nodes_path=eval_nodes,
+        do_training=not no_train,
+        do_evaluation=not no_eval,
+        metrics=metrics,
+        ks=ks,
+        config=config,
     )
-    # todo doku: mappings have to be in model folder with correct name, or change here
-    if not args.no_train:
-        print("starting training")
-        e.train()
-    if not args.no_eval:
-        print("starting evaluation")
-
-        metric_strings = args.metrics
-        metrics = [x for x in list(RankMetricType.__members__.values()) if x.name in metric_strings] + [
-            x for x in list(ThresholdMetricType.__members__.values()) if x.name in metric_strings
-        ]
-        int_ks = [int(k) for k in args.ks]
-
-        e.evaluate(metrics=metrics, ks=int_ks)
-
-
-def check_args_validity(args, parser):
-    # global checks
-    if not (args.g or args.s or args.e):
-        parser.error("at least one action is required [-g, -s, -e]")
-    if args.skip and args.no_interact is None:
-        parser.error("option --skip requires --no_interact")
-    # graph creation checks
-    if args.g:
-        if args.no_in and not args.no_dl and not args.no_create:
-            parser.error(
-                "Graph Creation: downloading graph files and creating the graph without creating in_files is not possible"
-            )
-    # train test split checks
-    if args.s:
-        if not args.edges or not args.tn_edges or not args.nodes:
-            parser.error(
-                "Train Test Split: paths to the edge file (--edges), negative edge file (--tn_edges) "
-                "and nodes file (--nodes) must be provided with option -s"
-            )
-        if args.crossval:
-            n_folds = args.val
-            if n_folds == 0 or n_folds == 1 or (n_folds > 1 and not float(n_folds).is_integer()):
-                parser.error(
-                    "fold entry must be either an int>1 (number of folds) or a float >0 and <1 (validation fraction)"
-                )
-        if args.mode == "time":
-            if not (bool(args.tmo_edges) and bool(args.tmo_tn_edges) and (bool(args.tmo_nodes))):
-                parser.error(
-                    "for time slice mode, edge-, tn-edge- and node-file of the t-minus-one graph must be provided"
-                )
-    # if args.crossval and (not args.tmo_edges or not args.tmo_tn_edges or not args.tmo_nodes):
-    #            parser.error("Train Test Split: paths to the t-1 edge file (--tmo_edges),"
-    #                         " t-1 negative edge file (--tmo_tn_edges) and t-1 nodes file (--tmo_nodes) "
-    #                         "must be provided with option --crossval") #todo what?
-
-
-def main(args_list=None):
-    if (len(sys.argv) < 2) and not args_list:
-        glob.GUI_MODE = True
-        import openbiolink.gui.gui as gui
-
-        gui.start_gui()
-        return
-
-    parser = argparse.ArgumentParser("OpenBioLink Toolbox")
-
-    # Global config
-    parser.add_argument(
-        "-p", type=str, default=os.getcwd(), help="specify a working directory (default = current working dictionary"
-    )
-
-    # Graph Creation
-    parser.add_argument("-g", action="store_true", help="Generate Graph")
-    parser.add_argument(
-        "--undir", action="store_true", help="Output-Graph should be undirectional (default = directional)"
-    )
-    parser.add_argument(
-        "--qual",
-        type=str,
-        help="quality level od the output-graph, options = [hq, mq, lq], (default = None -> all entries are used)",
-    )
-    parser.add_argument(
-        "--no_interact",
-        action="store_true",
-        help="Disables interactive mode - existing files will be replaced (default = interactive)",
-    )
-    parser.add_argument(
-        "--skip",
-        action="store_true",
-        help="Existing files will be skipped - in combination with --no_interact (default = replace)",
-    )
-    parser.add_argument(
-        "--no_dl", action="store_true", help="No download is being performed (e.g. when local data is used)"
-    )
-    parser.add_argument(
-        "--no_in", action="store_true", help="No input_files are created (e.g. when local data is used)"
-    )
-    parser.add_argument(
-        "--no_create", action="store_true", help="No graph is created (e.g. when only in-files should be created)"
-    )
-    parser.add_argument(
-        "--out_format",
-        nargs=3,
-        type=list,
-        default="TSV s t",
-        help="Format of graph output, takes 2 arguments: list of file formats [s= single file, m=multiple files] and list of separators (e.g. t=tab, n=newline, or any other character) (default= s t)",
-    )
-    parser.add_argument("--no_qscore", action="store_true", help="The output files will contain no scores")
-    parser.add_argument(
-        "--dbs", nargs="+", help="custom source databases selection to be used, full class name, options --> see doc"
-    )
-    parser.add_argument(
-        "--mes", nargs="+", help="custom meta edges selection to be used, full class name, options --> see doc"
-    )
-
-    # Train- Test Split Generation
-    parser.add_argument("-s", action="store_true", help="Generate Train-,Validation-, Test-Split")
-    parser.add_argument("--edges", type=str, help="Path to edges.csv file (required with action -s")
-    parser.add_argument("--tn_edges", type=str, help="Path to true_negatives_edges.csv file (required with action -s)")
-    parser.add_argument("--nodes", type=str, help="Path to nodes.csv file (required with action -s)")
-    parser.add_argument(
-        "--tts_sep",
-        type=str,
-        default="t",
-        help="Separator of edge, tn-edge and nodes file (e.g. t=tab, n=newline, or any other character) (default=t)",
-    )
-    parser.add_argument(
-        "--mode", type=str, default="rand", help="Mode of train-test-set split, options=[rand, time], (default=rand)"
-    )
-    parser.add_argument("--test_frac", type=float, default="0.2", help="Fraction of test set as float (default= 0.2)")
-    parser.add_argument("--crossval", action="store_true", help="Multiple train-validation-sets are generated")
-    parser.add_argument(
-        "--val",
-        type=float,
-        default="0.2",
-        help="Fraction of validation set as float (default= 0.2) or number of folds as int",
-    )
-    # niceToHave (1)
-    # parser.add_argument('--meta', type=str, help='Path to meta_edge triples (only required if meta-edges are not in OpenBioLink Benchmark Data)')
-    parser.add_argument(
-        "--tmo_edges", type=str, help="Path to edges.csv file of t-minus-one graph (required for --mode time"
-    )
-    parser.add_argument(
-        "--tmo_tn_edges",
-        type=str,
-        help="Path to true_negatives_edges.csv file of t-minus-one graph (required for --mode time",
-    )
-    parser.add_argument(
-        "--tmo_nodes", type=str, help="Path to nodes.csv file of t-minus-one graph (required for --mode time"
-    )
-
-    # Training and Evaluation
-    parser.add_argument("-e", action="store_true", help="Apply Training and Evaluation")
-    parser.add_argument("--model_cls", type=str, help="class of the model to be trained/evaluated (required with -e)")
-    parser.add_argument("--config", type=str, help="Path to the model' config file")
-    parser.add_argument(
-        "--no_train", action="store_true", help="No training is being performed, trained model id provided via --model"
-    )
-    parser.add_argument("--trained_model", type=str, help="Path to trained model (required with --no_train)")
-    parser.add_argument("--no_eval", action="store_true", help="No evaluation is being performed, only training")
-    parser.add_argument("--test", type=str, help="Path to test set file (required with -e)")
-    parser.add_argument("--train", type=str, help="Path to trainings set file")  # (alternative: --cv_folder)')
-    parser.add_argument(
-        "--corrupted",
-        type=str,
-        help="path to the corrupted triples (required for ranked triples if no nodes file is provided",
-    )  # fixme no longer an option
-    parser.add_argument(
-        "--eval_nodes",
-        type=str,
-        help="path to the nodes file (required for ranked triples if no corrupted triples file is provided and nodes cannot be taken from graph creation",
-    )
-    parser.add_argument("--metrics", nargs="+", help="evaluation metrics")
-    parser.add_argument("--ks", nargs="+", help="k's for hits@k metric")
-    # parser.add_argument('--cv_folder', type=str, help='Path to cross validation folder (alternative: --train)')
-
-    # niceToHave (7) option to load info from config file
-
-    if args_list:
-        args = parser.parse_args(args_list)
-    else:
-        args = parser.parse_args()
-
-    check_args_validity(args, parser)
-    glob.WORKING_DIR = args.p
-
-    if args.qual == "hq":
-        args.qual = QualityType.HQ
-    elif args.qual == "mq":
-        args.qual = QualityType.MQ
-    elif args.qual == "lq":
-        args.qual = QualityType.LQ
-
-    if args.g:
-        create_graph(args)
-    if args.s:
-        create_train_test_splits(args)
-    if args.e:
-        train_and_evaluate(args)
-
-    logging.info("Finished!")
 
 
 if __name__ == "__main__":
-    logger = logging.getLogger()
-    logger.setLevel("INFO")
-    pr = cProfile.Profile()
-    pr.enable()
     main()
-    base_dir = os.path.dirname(os.path.realpath(__file__))
-    test_folder = os.path.join(base_dir, "test")
-
-    pr.disable()
-    pr.print_stats(sort="time")
-
-    # todo crossval eval

--- a/src/openbiolink/openBioLink.py
+++ b/src/openbiolink/openBioLink.py
@@ -19,6 +19,7 @@ import click
 
 from openbiolink import globalConfig as glob
 from openbiolink.cli_helper import create_graph, train_and_evaluate
+from openbiolink.graph_creation import graphCreationConfig as gcConst
 from openbiolink.graph_creation.types.qualityType import QualityType
 from openbiolink.train_test_set_creation.trainTestSplitCreation import TrainTestSetCreation
 
@@ -50,7 +51,7 @@ def handle_quality(_, __, qual):
 @click.option(
     "--qual",
     type=click.Choice(["hq", "mq", "lq"]),
-    default='lq',
+    default="lq",
     show_default=True,
     callback=handle_quality,
     help="quality level od the output-graph (default = None -> all entries are used)",
@@ -65,8 +66,8 @@ def handle_quality(_, __, qual):
     is_flag=True,
     help="Existing files will be skipped - in combination with --no_interact (default = replace)",
 )
-@click.option("--no-dl", is_flag=True, help="No download is being performed (e.g. when local data is used)")
-@click.option("--no-in", is_flag=True, help="No input_files are created (e.g. when local data is used)")
+@click.option("--no-download", is_flag=True, help="No download is being performed (e.g. when local data is used)")
+@click.option("--no-input", is_flag=True, help="No input_files are created (e.g. when local data is used)")
 @click.option("--no-create", is_flag=True, help="No graph is created (e.g. when only in-files should be created)")
 @click.option("--no-qscore", is_flag=True, help="The output files will contain no scores")
 @click.option(
@@ -80,15 +81,15 @@ def generate(
     qual: QualityType,
     no_interact: bool,
     skip: bool,
-    no_dl: bool,
-    no_in: bool,
+    no_download: bool,
+    no_input: bool,
     no_create: bool,
     no_qscore: bool,
     dbs,
     mes,
 ):
     """Generate a graph."""
-    if no_in and not no_dl and not no_create:
+    if no_input and not no_download and not no_create:
         click.secho(
             "Graph Creation: downloading graph files and creating the graph without creating in_files is not possible",
             fg="red",
@@ -100,8 +101,8 @@ def generate(
         quality_type=qual,
         interactive_mode=not no_interact,
         skip_existing_files=skip,
-        do_download=not no_dl,
-        do_create_input_files=not no_in,
+        do_download=not no_download,
+        do_create_input_files=not no_input,
         do_create_graph=not no_create,
         qscore=not no_qscore,
         dbs=dbs,

--- a/src/openbiolink/openBioLink.py
+++ b/src/openbiolink/openBioLink.py
@@ -76,20 +76,20 @@ def handle_quality(_, __, qual):
     type=click.Choice(list(FORMATS)),
     default="TSV",
     show_default=True,
-    help="Format of output files TSV or RDF-N3"
+    help="Format of output files TSV or RDF-N3",
 )
 @click.option(
     "--output-sep",
     default="t",
     show_default=True,
-    help="Seperator used in the output files (t = tab seperated, n = newline, or any other char)"
+    help="Seperator used in the output files (t = tab seperated, n = newline, or any other char)",
 )
 @click.option(
     "--output-multi-file",
     is_flag=True,
     default=False,
-    help="Edges and nodes are written to multiple files, instead of" 
-         "single files (accordingly grouped by edge type and node type)"
+    help="Edges and nodes are written to multiple files, instead of"
+    "single files (accordingly grouped by edge type and node type)",
 )
 @click.option(
     "--dbs", multiple=True, help="custom source databases selection to be used, full class name, options --> see doc"

--- a/src/openbiolink/openBioLink.py
+++ b/src/openbiolink/openBioLink.py
@@ -71,9 +71,26 @@ def handle_quality(_, __, qual):
 @click.option("--no-input", is_flag=True, help="No input_files are created (e.g. when local data is used)")
 @click.option("--no-create", is_flag=True, help="No graph is created (e.g. when only in-files should be created)")
 @click.option("--no-qscore", is_flag=True, help="The output files will contain no scores")
-@click.option("--output-format", type=click.Choice(list(FORMATS)), default="TSV", show_default=True)
-@click.option("--output-single-sep")
-@click.option("--output-multi-sep")
+@click.option(
+    "--output-format",
+    type=click.Choice(list(FORMATS)),
+    default="TSV",
+    show_default=True,
+    help="Format of output files TSV or RDF-N3"
+)
+@click.option(
+    "--output-sep",
+    default="t",
+    show_default=True,
+    help="Seperator used in the output files (t = tab seperated, n = newline, or any other char)"
+)
+@click.option(
+    "--output-multi-file",
+    is_flag=True,
+    default=False,
+    help="Edges and nodes are written to multiple files, instead of" 
+         "single files (accordingly grouped by edge type and node type)"
+)
 @click.option(
     "--dbs", multiple=True, help="custom source databases selection to be used, full class name, options --> see doc"
 )
@@ -90,8 +107,8 @@ def generate(
     no_create: bool,
     no_qscore: bool,
     output_format: str,
-    output_single_sep,
-    output_multi_sep,
+    output_sep: str,
+    output_multi_file: bool,
     dbs,
     mes,
 ):
@@ -113,8 +130,8 @@ def generate(
         do_create_graph=not no_create,
         qscore=not no_qscore,
         output_format=output_format,
-        output_single_sep=output_single_sep,
-        output_multisep_sep=output_multi_sep,
+        output_sep=output_sep,
+        output_multi=output_multi_file,
         dbs=dbs,
         mes=mes,
     )

--- a/src/openbiolink/train_test_set_creation/trainTestSplitCreation.py
+++ b/src/openbiolink/train_test_set_creation/trainTestSplitCreation.py
@@ -3,6 +3,7 @@ import math
 import os
 import random
 import sys
+from typing import Optional
 
 import numpy
 import pandas
@@ -58,28 +59,30 @@ class TrainTestSetCreation:
         graph_path,
         tn_graph_path,
         all_nodes_path,
-        sep="\t",
+        sep: Optional[str] = None,
         # meta_edge_triples=None, #nicetohave (1) split for subsample of edges, define own meta edges
         t_minus_one_graph_path=None,
         t_minus_one_tn_graph_path=None,
         t_minus_one_nodes_path=None,
     ):
-        if os.path.splitext(graph_path)[1] != ".csv":
+        if sep is None:
+            sep = "\t"
+        if _not_csv(graph_path):
             logging.error("graph path must be a csv file")
             sys.exit()
-        if os.path.splitext(tn_graph_path)[1] != ".csv":
+        if _not_csv(tn_graph_path):
             logging.error("tn_graph path must be a csv file")
             sys.exit()
-        if os.path.splitext(all_nodes_path)[1] != ".csv":
+        if _not_csv(all_nodes_path):
             logging.error("all_nodes path must be a csv file")
             sys.exit()
-        if t_minus_one_graph_path is not None and os.path.splitext(t_minus_one_graph_path)[1] != ".csv":
+        if t_minus_one_graph_path is not None and _not_csv(t_minus_one_graph_path):
             logging.error("t_minus_one_graph path must be a csv file")
             sys.exit()
-        if t_minus_one_tn_graph_path is not None and os.path.splitext(t_minus_one_tn_graph_path)[1] != ".csv":
+        if t_minus_one_tn_graph_path is not None and _not_csv(t_minus_one_tn_graph_path):
             logging.error("t_minus_one_tn_graph path must be a csv file")
             sys.exit()
-        if t_minus_one_nodes_path is not None and os.path.splitext(t_minus_one_nodes_path)[1] != ".csv":
+        if t_minus_one_nodes_path is not None and _not_csv(t_minus_one_nodes_path):
             logging.error("t_minus_one_nodes path must be a csv file")
             sys.exit()
 
@@ -189,7 +192,8 @@ class TrainTestSetCreation:
                 )
                 if new_val_nodes:  # nicetohave (6)
                     logging.info(
-                        f"Validation set {i} contains nodes that are not present in the trainings-set. These edges will be dropped."
+                        f"Validation set {i} contains nodes that are"
+                        f" not present in the training set. These edges will be dropped."
                     )
                     val_set = self.remove_edges_with_nodes(val_set, new_val_nodes)
                     train_val_set_tuples[i] = (train_set, val_set)
@@ -250,7 +254,7 @@ class TrainTestSetCreation:
         )
         if new_test_nodes:
             logging.info(
-                "The test set contains nodes, that are not present in the trainings-set. These edges will be removed."
+                "The test set contains nodes that are not present in the trainings-set. These edges will be removed."
             )  # nicetohave (6)
             test_set = self.remove_edges_with_nodes(test_set, new_test_nodes)
 
@@ -339,3 +343,7 @@ class TrainTestSetCreation:
             folds.append((df.loc[train_indices], df.loc[val_indices]))
 
         return folds
+
+
+def _not_csv(f):
+    return os.path.splitext(f)[1] not in {".csv", ".tsv"}

--- a/src/openbiolink/train_test_set_creation/trainTestSplitCreation.py
+++ b/src/openbiolink/train_test_set_creation/trainTestSplitCreation.py
@@ -15,7 +15,6 @@ from openbiolink.train_test_set_creation.trainTestSetWriter import TrainTestSetW
 
 random.seed(glob.RANDOM_STATE)
 numpy.random.seed(glob.RANDOM_STATE)
-logger = logging.getLogger(__name__)
 
 
 class TrainTestSetCreation:
@@ -66,36 +65,36 @@ class TrainTestSetCreation:
         t_minus_one_nodes_path=None,
     ):
         if os.path.splitext(graph_path)[1] != ".csv":
-            logger.error("graph path must be a csv file")
+            logging.error("graph path must be a csv file")
             sys.exit()
         if os.path.splitext(tn_graph_path)[1] != ".csv":
-            logger.error("tn_graph path must be a csv file")
+            logging.error("tn_graph path must be a csv file")
             sys.exit()
         if os.path.splitext(all_nodes_path)[1] != ".csv":
-            logger.error("all_nodes path must be a csv file")
+            logging.error("all_nodes path must be a csv file")
             sys.exit()
         if t_minus_one_graph_path is not None and os.path.splitext(t_minus_one_graph_path)[1] != ".csv":
-            logger.error("t_minus_one_graph path must be a csv file")
+            logging.error("t_minus_one_graph path must be a csv file")
             sys.exit()
         if t_minus_one_tn_graph_path is not None and os.path.splitext(t_minus_one_tn_graph_path)[1] != ".csv":
-            logger.error("t_minus_one_tn_graph path must be a csv file")
+            logging.error("t_minus_one_tn_graph path must be a csv file")
             sys.exit()
         if t_minus_one_nodes_path is not None and os.path.splitext(t_minus_one_nodes_path)[1] != ".csv":
-            logger.error("t_minus_one_nodes path must be a csv file")
+            logging.error("t_minus_one_nodes path must be a csv file")
             sys.exit()
 
         self.writer = TrainTestSetWriter()
-        logger.info(f"loading nodes from {all_nodes_path}")
+        logging.info(f"loading nodes from {all_nodes_path}")
         self.all_nodes = pandas.read_csv(all_nodes_path, sep=sep, names=globalConfig.COL_NAMES_NODES)
         self.all_nodes = self.all_nodes.sort_values(by=globalConfig.COL_NAMES_NODES).reset_index(drop=True)
 
-        logger.info(f"loading true edges from {graph_path}")
+        logging.info(f"loading true edges from {graph_path}")
         self.all_tp = pandas.read_csv(graph_path, sep=sep, names=globalConfig.COL_NAMES_EDGES)
         self.all_tp[globalConfig.VALUE_COL_NAME] = 1
         self.all_tp = self.all_tp.sort_values(by=globalConfig.COL_NAMES_EDGES).reset_index(drop=True)
         self.tp_edgeTypes = list(self.all_tp[globalConfig.EDGE_TYPE_COL_NAME].unique())
 
-        logger.info(f"loading false edges from {tn_graph_path}")
+        logging.info(f"loading false edges from {tn_graph_path}")
         self.all_tn = pandas.read_csv(tn_graph_path, sep=sep, names=globalConfig.COL_NAMES_EDGES)
         self.all_tn[globalConfig.VALUE_COL_NAME] = 0
         self.all_tn = self.all_tn.sort_values(by=globalConfig.COL_NAMES_EDGES).reset_index(drop=True)
@@ -122,7 +121,7 @@ class TrainTestSetCreation:
 
         # for time slices
         if not (bool(t_minus_one_graph_path) == bool(t_minus_one_tn_graph_path) == (bool(t_minus_one_nodes_path))):
-            logger.error("either all three or none of these variables must be provided")
+            logging.error("either all three or none of these variables must be provided")
             sys.exit()
         if (
             t_minus_one_nodes_path is not None
@@ -168,7 +167,7 @@ class TrainTestSetCreation:
             old_nodes_list=nodes_in_train_val_set, new_nodes_list=self.all_nodes[globalConfig.ID_NODE_COL_NAME].tolist()
         )
         if new_test_nodes:
-            logger.info(
+            logging.info(
                 "The test set contains nodes, that are not present in the trainings-set. These edges will be dropped."
             )  # nicetohave (6): option to keep edges with new nodes
             test_set = self.remove_edges_with_nodes(test_set, new_test_nodes)
@@ -189,7 +188,7 @@ class TrainTestSetCreation:
                     new_nodes_list=nodes_in_train_val_set,
                 )
                 if new_val_nodes:  # nicetohave (6)
-                    logger.info(
+                    logging.info(
                         f"Validation set {i} contains nodes that are not present in the trainings-set. These edges will be dropped."
                     )
                     val_set = self.remove_edges_with_nodes(val_set, new_val_nodes)
@@ -237,7 +236,7 @@ class TrainTestSetCreation:
         )
         test_tn_samples, vanished_tn_samples = utils.get_diff(self.all_tn, self.tmo_all_tn, ignore_qscore=True)
         if not vanished_positive_samples.empty or not vanished_tn_samples.empty:
-            logger.info("Some edges existing in the first time slice are no longer present in the second one")
+            logging.info("Some edges existing in the first time slice are no longer present in the second one")
             self.writer.print_vanished_edges(vanished_positive_samples.append(vanished_tn_samples))
         test_negative_sampler = NegativeSampler(self.meta_edges_dic, self.tn_edgeTypes, test_tn_samples, self.all_nodes)
         test_negative_samples = test_negative_sampler.generate_random_neg_samples(test_positive_samples)
@@ -250,7 +249,7 @@ class TrainTestSetCreation:
             new_nodes_list=self.all_nodes[globalConfig.ID_NODE_COL_NAME].tolist(),
         )
         if new_test_nodes:
-            logger.info(
+            logging.info(
                 "The test set contains nodes, that are not present in the trainings-set. These edges will be removed."
             )  # nicetohave (6)
             test_set = self.remove_edges_with_nodes(test_set, new_test_nodes)
@@ -306,7 +305,7 @@ class TrainTestSetCreation:
     def create_cross_val(df: pandas.DataFrame, n_folds):
         nel_total, _ = df.shape
         if n_folds == 0 or n_folds == 1 or (n_folds > 1 and not float(n_folds).is_integer()):
-            logger.error("provided folds are not possible!")
+            logging.error("provided folds are not possible!")
             raise Exception(
                 "fold entry must be either an int>1 (number of folds) or a float >0 and <1 (validation fraction)"
             )

--- a/test/graph_creation_tests/test_graphCreator.py
+++ b/test/graph_creation_tests/test_graphCreator.py
@@ -6,7 +6,7 @@ sys.path.append(os.path.abspath("src/openbiolink"))
 
 import globalConfig
 import graphProperties as graphProp
-from src.openbiolink.graph_creation.graphCreation import Graph_Creation
+from src.openbiolink.graph_creation.graphCreation import GraphCreator
 from src.openbiolink.graph_creation.metadata_db_file import *
 
 
@@ -131,7 +131,7 @@ class TestGraphCreation(unittest.TestCase):
             with self.subTest(graph_is_directed=graph_is_directed):
                 graphProp.DIRECTED = graph_is_directed
 
-                graph_creator = Graph_Creation(test_data_folder, manual_db_file_metadata)
+                graph_creator = GraphCreator(test_data_folder, manual_db_file_metadata)
                 graph_creator.create_input_files()
                 graph_creator.create_graph(one_file_sep="\t", multi_file_sep="\t")
 

--- a/test/graph_creation_tests/test_graphCreator.py
+++ b/test/graph_creation_tests/test_graphCreator.py
@@ -3,7 +3,7 @@ import unittest
 
 import openbiolink.graphProperties as graphProp
 from openbiolink import globalConfig
-from openbiolink.graph_creation.graphCreation import GraphCreation
+from openbiolink.graph_creation.graphCreation import Graph_Creation
 from openbiolink.graph_creation.metadata_db_file import *
 
 
@@ -127,7 +127,7 @@ class TestGraphCreation(unittest.TestCase):
             with self.subTest(graph_is_directed=graph_is_directed):
                 graphProp.DIRECTED = graph_is_directed
 
-                graph_creator = GraphCreation(test_data_folder, manual_db_file_metadata)
+                graph_creator = Graph_Creation(test_data_folder, manual_db_file_metadata)
                 graph_creator.create_input_files()
                 graph_creator.create_graph(one_file_sep="\t", multi_file_sep="\t")
 

--- a/test/graph_creation_tests/test_graphCreator.py
+++ b/test/graph_creation_tests/test_graphCreator.py
@@ -1,18 +1,14 @@
 import os
 import unittest
-import sys
 
-sys.path.append(os.path.abspath("src/openbiolink"))
-
-import globalConfig
-import graphProperties as graphProp
-from src.openbiolink.graph_creation.graphCreation import GraphCreator
-from src.openbiolink.graph_creation.metadata_db_file import *
+import openbiolink.graphProperties as graphProp
+from openbiolink import globalConfig
+from openbiolink.graph_creation.graphCreation import GraphCreation
+from openbiolink.graph_creation.metadata_db_file import *
 
 
 class TestGraphCreation(unittest.TestCase):
     def test_graph_creation(self):
-
         # creates test graph from test o_files and compares against true reference test graph
         # tests directed and undirected version of graph (and TN-graph)
         # well as the output into a single as well as in separate files
@@ -131,7 +127,7 @@ class TestGraphCreation(unittest.TestCase):
             with self.subTest(graph_is_directed=graph_is_directed):
                 graphProp.DIRECTED = graph_is_directed
 
-                graph_creator = GraphCreator(test_data_folder, manual_db_file_metadata)
+                graph_creator = GraphCreation(test_data_folder, manual_db_file_metadata)
                 graph_creator.create_input_files()
                 graph_creator.create_graph(one_file_sep="\t", multi_file_sep="\t")
 


### PR DESCRIPTION
Closes #24 and closes #25

This PR switches the CLI from using `argparse` to `click`. This comes with a few added benefits, including better automatic generation of help messages, the creation of sub-commands, the cleanup of flags.

~Right now this PR is marked as a draft because I have still yet to successfully generate a new graph.~ I've finally been able to download, parse, and output all of the files as TSV :smile:

One of the big issues I've found in the logic in this package is the global variables in from `openbiolink import globalConfig` - it makes the logic very nonlinear and hard to organize. It would be better for each function to take the values stored in the global configuration as arguments and only have the CLI or the user make the choices explicitly when calling those functions. This could be done in a subsequent PR