### PR TITLE
Refactor graph writers

### DIFF
--- a/src/openbiolink/graph_creation/graphCreation.py
+++ b/src/openbiolink/graph_creation/graphCreation.py
@@ -166,7 +166,7 @@ class Graph_Creation:
             graph_writer = GraphTSVWriter(file_sep=file_sep, multi_file=multi_file, print_qscore=print_qscore)
         elif format == "RDF-N3":
             graph_writer = GraphRDFWriter(file_sep=file_sep, multi_file=multi_file, print_qscore=print_qscore)
-        elif format == 'PICKLE':
+        elif format == "PICKLE":
             graph_writer = GraphPickleWriter()
         else:
             raise ValueError(f"Invalid format: {format}")

--- a/src/openbiolink/graph_creation/graphCreation.py
+++ b/src/openbiolink/graph_creation/graphCreation.py
@@ -23,7 +23,6 @@ from openbiolink.gui.tqdmbuf import TqdmBuffer
 FORMATS = {
     "TSV": GraphTSVWriter,
     "RDF-N3": GraphRDFWriter,
-    "BEL": GraphBELGraphWriter,
 }
 
 
@@ -164,9 +163,9 @@ class Graph_Creation:
         format = format.upper()
 
         if format == "TSV":
-            graph_writer = GraphTSVWriter(file_sep=file_sep, multi_file=multi_file, print_qscore=print_qscore,)
+            graph_writer = GraphTSVWriter(file_sep=file_sep, multi_file=multi_file, print_qscore=print_qscore)
         elif format == "RDF-N3":
-            graph_writer = GraphRDFWriter(file_sep=file_sep, multi_file=multi_file, print_qscore=print_qscore,)
+            graph_writer = GraphRDFWriter(file_sep=file_sep, multi_file=multi_file, print_qscore=print_qscore)
         else:
             raise ValueError(f"Invalid format: {format}")
 

--- a/src/openbiolink/graph_creation/graphCreation.py
+++ b/src/openbiolink/graph_creation/graphCreation.py
@@ -166,6 +166,8 @@ class Graph_Creation:
             graph_writer = GraphTSVWriter(file_sep=file_sep, multi_file=multi_file, print_qscore=print_qscore)
         elif format == "RDF-N3":
             graph_writer = GraphRDFWriter(file_sep=file_sep, multi_file=multi_file, print_qscore=print_qscore)
+        elif format == 'PICKLE':
+            graph_writer = GraphPickleWriter()
         else:
             raise ValueError(f"Invalid format: {format}")
 

--- a/src/openbiolink/graph_creation/graph_writer/__init__.py
+++ b/src/openbiolink/graph_creation/graph_writer/__init__.py
@@ -1,2 +1,3 @@
 from openbiolink.graph_creation.graph_writer.graphRDFWriter import GraphRDFWriter
 from openbiolink.graph_creation.graph_writer.graphTSVWriter import GraphTSVWriter
+from openbiolink.graph_creation.graph_writer.pickle_writer import GraphPickleWriter

--- a/src/openbiolink/graph_creation/graph_writer/base.py
+++ b/src/openbiolink/graph_creation/graph_writer/base.py
@@ -11,6 +11,13 @@ from openbiolink.graph_creation import graphCreationConfig as gcConst
 class GraphWriter(ABC):
     """A class that can write information to a directory."""
 
+    def __init__(self, *, directory: Optional[str] = None):
+        if directory is None:
+            self.graph_dir_path = os.path.join(globConst.WORKING_DIR, gcConst.GRAPH_FILES_FOLDER_NAME)
+        else:
+            self.graph_dir_path = directory
+        os.makedirs(self.graph_dir_path, exist_ok=True)
+
     @abstractmethod
     def write(
         self, *, tp_nodes, tp_edges: Mapping[str, Edge], tp_namespaces, tn_nodes, tn_edges, tn_namespaces,
@@ -21,12 +28,8 @@ class GraphWriter(ABC):
 class OpenBioLinkGraphWriter(GraphWriter):
     """A writer class that abstracts the OpenBioLink RDF and TSV exporters."""
 
-    def __init__(
-        self, *, multi_file, print_qscore: bool, file_sep: Optional[str] = None,
-    ):
-        self.graph_dir_path = os.path.join(globConst.WORKING_DIR, gcConst.GRAPH_FILES_FOLDER_NAME)
-        os.makedirs(self.graph_dir_path, exist_ok=True)
-
+    def __init__(self, *, multi_file, print_qscore: bool, file_sep: Optional[str] = None):
+        super().__init__()
         self.multi_file = multi_file
         self.print_qscore = print_qscore
         if file_sep is None:

--- a/src/openbiolink/graph_creation/graph_writer/base.py
+++ b/src/openbiolink/graph_creation/graph_writer/base.py
@@ -1,0 +1,96 @@
+import json
+import os
+from abc import ABC, abstractmethod
+from typing import Mapping
+
+from openbiolink import globalConfig as globConst, graphProperties
+from openbiolink.edge import Edge
+from openbiolink.graph_creation import graphCreationConfig as gcConst
+
+
+class GraphWriter(ABC):
+    """A class that can write information to a directory."""
+
+    @abstractmethod
+    def write(
+        self, *, tp_nodes, tp_edges: Mapping[str, Edge], tp_namespaces, tn_nodes, tn_edges, tn_namespaces,
+    ):
+        raise NotImplementedError
+
+
+class OpenBioLinkGraphWriter(GraphWriter):
+    """A writer class that abstracts the OpenBioLink RDF and TSV exporters."""
+
+    def __init__(
+        self, multi_file, print_qscore, file_sep=None,
+    ):
+        self.graph_dir_path = os.path.join(globConst.WORKING_DIR, gcConst.GRAPH_FILES_FOLDER_NAME)
+        os.makedirs(self.graph_dir_path, exist_ok=True)
+        self.multi_file = multi_file
+        self.print_qscore = print_qscore
+        if file_sep is None:
+            file_sep = "\t"
+        self.file_sep = file_sep
+
+    def output_graph_props(self):
+        graph_prop_dict = {
+            key: getattr(graphProperties, key) for key in dir(graphProperties) if not key.startswith("__")
+        }
+
+        # Sanitize - not necessary since all types can be dumped to JSON?
+        # for k, v in graph_prop_dict.items():
+        #    if not isinstance(v, str):
+        #        graph_prop_dict[k] = str(v)
+
+        with open(os.path.join(self.graph_dir_path, "graph_props.json"), "w") as file:
+            json.dump(graph_prop_dict, file, indent=2)
+
+    def write_node_and_edge_list(self, prefix, nodes_list, edges_list):
+        with open(os.path.join(self.graph_dir_path, prefix + "nodes_list.csv"), "w") as out_file:
+            out_file.writelines(list("\n".join(nodes_list)))
+
+        with open(os.path.join(self.graph_dir_path, prefix + "edges_list.csv"), "w") as out_file:
+            out_file.writelines(list("\n".join(edges_list)))
+
+    @abstractmethod
+    def output_graph(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def write(
+        self, *, tp_nodes, tp_edges: Mapping[str, Edge], tp_namespaces, tn_nodes, tn_edges, tn_namespaces,
+    ):
+        self.output_graph(
+            tp_nodes, tp_edges, file_sep=self.file_sep, multi_file=self.multi_file, print_qscore=self.print_qscore,
+        )
+        # create/output negative edges
+
+        self.output_graph(
+            tn_nodes,
+            tn_edges,
+            file_sep=self.file_sep,
+            multi_file=self.multi_file,
+            prefix="TN_",
+            print_qscore=self.print_qscore,
+        )
+
+        all_nodes_dic = tp_nodes.copy()
+        for key, values in tn_nodes.items():
+            if key in all_nodes_dic.keys():
+                temp = set(all_nodes_dic[key])
+                temp.update(set(values))
+                values = temp
+            all_nodes_dic[key] = values
+        self.output_graph(
+            all_nodes_dic,
+            None,
+            file_sep=self.file_sep,
+            multi_file=False,
+            prefix="ALL_",
+            print_qscore=False,
+            node_edge_list=False,
+        )
+
+        graphProperties.EDGE_TYPES = list(tp_edges.keys())
+        graphProperties.NODE_TYPES = list(tp_nodes.keys())
+        graphProperties.NODE_NAMESPACES = list(tp_namespaces)
+        self.output_graph_props()

--- a/src/openbiolink/graph_creation/graph_writer/graphRDFWriter.py
+++ b/src/openbiolink/graph_creation/graph_writer/graphRDFWriter.py
@@ -1,29 +1,14 @@
-import json
 import os
 
-import openbiolink.graphProperties as graphProp
-from openbiolink import globalConfig as globConst
 from openbiolink.graph_creation import graphCreationConfig as gcConst
+from openbiolink.graph_creation.graph_writer.base import OpenBioLinkGraphWriter
 
 
-class GraphRDFWriter:
+class GraphRDFWriter(OpenBioLinkGraphWriter):
     identifiersURL = "https://identifiers.org/"
 
-    def __init__(self):
-        self.graph_dir_path = os.path.join(globConst.WORKING_DIR, gcConst.GRAPH_FILES_FOLDER_NAME)
-        os.makedirs(self.graph_dir_path, exist_ok=True)
-
-    def output_graph_props(self):
-        graph_prop_list = [item for item in dir(graphProp) if not item.startswith("__")]
-        graph_prop_dict = {var: getattr(graphProp, var) for var in graph_prop_list}
-        with open(os.path.join(self.graph_dir_path, "graph_props.json"), "w") as json_file:
-            for k, v in graph_prop_dict.items():
-                if not type(v) == str:
-                    graph_prop_dict[k] = str(v)
-            json.dump(graph_prop_dict, json_file, indent=4)
-
-    @staticmethod
     def output_graph(
+        self,
         nodes_dic: dict = None,
         edges_dic: dict = None,
         file_sep=None,
@@ -40,16 +25,16 @@ class GraphRDFWriter:
 
         # separate files
         if multi_file:
-            GraphRDFWriter().output_graph_in_multi_files(prefix, file_sep, nodes_dic, edges_dic, qscore=print_qscore)
+            self.output_graph_in_multi_files(prefix, file_sep, nodes_dic, edges_dic, qscore=print_qscore)
         # one file
         else:
-            GraphRDFWriter().output_graph_in_single_file(
+            self.output_graph_in_single_file(
                 prefix=prefix, file_sep=file_sep, nodes_dic=nodes_dic, edges_dic=edges_dic, qscore=print_qscore
             )
 
         # lists of all nodes and metaedges
         if node_edge_list:
-            GraphRDFWriter().write_node_and_edge_list(prefix, nodes_dic.keys(), edges_dic.keys())
+            self.write_node_and_edge_list(prefix, nodes_dic.keys(), edges_dic.keys())
 
         # niceToHave (8) adjacency matrix
         # key, value = nodes_dic
@@ -142,10 +127,3 @@ class GraphRDFWriter:
                             + edge.sourcedb
                             + "\n"
                         )
-
-    def write_node_and_edge_list(self, prefix, nodes_list, edges_list):
-        with open(os.path.join(self.graph_dir_path, prefix + "nodes_list.csv"), "w") as out_file:
-            out_file.writelines(list("\n".join(nodes_list)))
-
-        with open(os.path.join(self.graph_dir_path, prefix + "edges_list.csv"), "w") as out_file:
-            out_file.writelines(list("\n".join(edges_list)))

--- a/src/openbiolink/graph_creation/graph_writer/graphTSVWriter.py
+++ b/src/openbiolink/graph_creation/graph_writer/graphTSVWriter.py
@@ -1,28 +1,13 @@
 import csv
-import json
 import os
 
-import openbiolink.graphProperties as graphProp
-from openbiolink import globalConfig as globConst
 from openbiolink.graph_creation import graphCreationConfig as gcConst
+from openbiolink.graph_creation.graph_writer.base import OpenBioLinkGraphWriter
 
 
-class GraphTSVWriter:
-    def __init__(self):
-        self.graph_dir_path = os.path.join(globConst.WORKING_DIR, gcConst.GRAPH_FILES_FOLDER_NAME)
-        os.makedirs(self.graph_dir_path, exist_ok=True)
-
-    def output_graph_props(self):
-        graph_prop_list = [item for item in dir(graphProp) if not item.startswith("__")]
-        graph_prop_dict = {var: getattr(graphProp, var) for var in graph_prop_list}
-        with open(os.path.join(self.graph_dir_path, "graph_props.json"), "w") as json_file:
-            for k, v in graph_prop_dict.items():
-                if not type(v) == str:
-                    graph_prop_dict[k] = str(v)
-            json.dump(graph_prop_dict, json_file, indent=4)
-
-    @staticmethod
+class GraphTSVWriter(OpenBioLinkGraphWriter):
     def output_graph(
+        self,
         nodes_dic: dict = None,
         edges_dic: dict = None,
         file_sep=None,
@@ -39,16 +24,16 @@ class GraphTSVWriter:
 
         # separate files
         if multi_file:
-            GraphTSVWriter().output_graph_in_multi_files(prefix, file_sep, nodes_dic, edges_dic, qscore=print_qscore)
+            self.output_graph_in_multi_files(prefix, file_sep, nodes_dic, edges_dic, qscore=print_qscore)
         # one file
         else:
-            GraphTSVWriter().output_graph_in_single_file(
+            self.output_graph_in_single_file(
                 prefix=prefix, file_sep=file_sep, nodes_dic=nodes_dic, edges_dic=edges_dic, qscore=print_qscore
             )
 
         # lists of all nodes and metaedges
         if node_edge_list:
-            GraphTSVWriter().write_node_and_edge_list(prefix, nodes_dic.keys(), edges_dic.keys())
+            self.write_node_and_edge_list(prefix, nodes_dic.keys(), edges_dic.keys())
 
         # niceToHave (8) adjacency matrix
         # key, value = nodes_dic
@@ -75,27 +60,19 @@ class GraphTSVWriter:
     def output_graph_in_multi_files(self, prefix, file_sep, nodes_dic, edges_dic, qscore):
         # write nodes
         for key, value in nodes_dic.items():
-            with open(
-                os.path.join(self.graph_dir_path, prefix + gcConst.NODES_FILE_PREFIX + "_" + key + ".csv"), "w"
-            ) as out_file:
+            nodes_path = os.path.join(self.graph_dir_path, f"{prefix}{gcConst.NODES_FILE_PREFIX}_{key}.csv")
+            with open(nodes_path, "w") as out_file:
                 writer = csv.writer(out_file, delimiter=file_sep, lineterminator="\n")
                 for node in value:
                     writer.writerow(list(node))
+
         # write edges
         for key, value in edges_dic.items():
-            with open(
-                os.path.join(self.graph_dir_path, prefix + gcConst.EDGES_FILE_PREFIX + "_" + key + ".csv"), "w"
-            ) as out_file:
+            edges_path = os.path.join(self.graph_dir_path, f"{prefix}{gcConst.EDGES_FILE_PREFIX}_{key}.csv")
+            with open(edges_path, "w") as out_file:
                 writer = csv.writer(out_file, delimiter=file_sep, lineterminator="\n")
                 for edge in value:
                     if qscore:
                         writer.writerow(list(edge))
                     else:
                         writer.writerow(edge.to_sub_rel_obj_list())
-
-    def write_node_and_edge_list(self, prefix, nodes_list, edges_list):
-        with open(os.path.join(self.graph_dir_path, prefix + "nodes_list.csv"), "w") as out_file:
-            out_file.writelines(list("\n".join(nodes_list)))
-
-        with open(os.path.join(self.graph_dir_path, prefix + "edges_list.csv"), "w") as out_file:
-            out_file.writelines(list("\n".join(edges_list)))

--- a/src/openbiolink/graph_creation/graph_writer/graphTSVWriter.py
+++ b/src/openbiolink/graph_creation/graph_writer/graphTSVWriter.py
@@ -1,5 +1,6 @@
 import csv
 import os
+from typing import Mapping
 
 from openbiolink.graph_creation import graphCreationConfig as gcConst
 from openbiolink.graph_creation.graph_writer.base import OpenBioLinkGraphWriter
@@ -7,62 +8,50 @@ from openbiolink.graph_creation.graph_writer.base import OpenBioLinkGraphWriter
 
 class GraphTSVWriter(OpenBioLinkGraphWriter):
     def output_graph(
-        self,
-        nodes_dic: dict = None,
-        edges_dic: dict = None,
-        file_sep=None,
-        multi_file=None,
-        prefix=None,
-        print_qscore=True,
-        node_edge_list=True,
+        self, nodes: Mapping = None, edges: Mapping = None, prefix=None, node_edge_list=True,
     ):
-        if not prefix:
+        if prefix is None:
             prefix = ""
 
-        if file_sep is None:
-            file_sep = ","
-
         # separate files
-        if multi_file:
-            self.output_graph_in_multi_files(prefix, file_sep, nodes_dic, edges_dic, qscore=print_qscore)
+        if self.multi_file:
+            self._output_graph_in_multi_files(prefix=prefix, nodes=nodes, edges=edges)
         # one file
         else:
-            self.output_graph_in_single_file(
-                prefix=prefix, file_sep=file_sep, nodes_dic=nodes_dic, edges_dic=edges_dic, qscore=print_qscore
-            )
+            self._output_graph_in_single_file(prefix=prefix, nodes=nodes, edges=edges)
 
         # lists of all nodes and metaedges
         if node_edge_list:
-            self.write_node_and_edge_list(prefix, nodes_dic.keys(), edges_dic.keys())
+            self.write_node_and_edge_list(prefix, nodes.keys(), edges.keys())
 
         # niceToHave (8) adjacency matrix
         # key, value = nodes_dic
         # d = {x: i for i, x in enumerate(value)}
         # niceToHave (8) outputformat for graph DB
 
-    def output_graph_in_single_file(self, prefix, file_sep, nodes_dic, edges_dic, qscore):
-        if nodes_dic is not None:
+    def _output_graph_in_single_file(self, *, prefix, nodes, edges):
+        if nodes is not None:
             with open(os.path.join(self.graph_dir_path, prefix + gcConst.NODES_FILE_PREFIX + ".csv"), "w") as out_file:
-                writer = csv.writer(out_file, delimiter=file_sep, lineterminator="\n")
-                for key, value in nodes_dic.items():
+                writer = csv.writer(out_file, delimiter=self.file_sep, lineterminator="\n")
+                for key, value in nodes.items():
                     for node in value:
                         writer.writerow(list(node))
-        if edges_dic is not None:
+        if edges is not None:
             with open(os.path.join(self.graph_dir_path, prefix + gcConst.EDGES_FILE_PREFIX + ".csv"), "w") as out_file:
-                writer = csv.writer(out_file, delimiter=file_sep, lineterminator="\n")
-                for key, value in edges_dic.items():
+                writer = csv.writer(out_file, delimiter=self.file_sep, lineterminator="\n")
+                for key, value in edges.items():
                     for edge in value:
-                        if qscore:
+                        if self.print_qscore:
                             writer.writerow(list(edge))
                         else:
                             writer.writerow(edge.to_sub_rel_obj_list())
 
-    def output_graph_in_multi_files(self, prefix, file_sep, nodes_dic, edges_dic, qscore):
+    def _output_graph_in_multi_files(self, *, prefix, nodes_dic, edges_dic):
         # write nodes
         for key, value in nodes_dic.items():
             nodes_path = os.path.join(self.graph_dir_path, f"{prefix}{gcConst.NODES_FILE_PREFIX}_{key}.csv")
             with open(nodes_path, "w") as out_file:
-                writer = csv.writer(out_file, delimiter=file_sep, lineterminator="\n")
+                writer = csv.writer(out_file, delimiter=self.file_sep, lineterminator="\n")
                 for node in value:
                     writer.writerow(list(node))
 
@@ -70,9 +59,9 @@ class GraphTSVWriter(OpenBioLinkGraphWriter):
         for key, value in edges_dic.items():
             edges_path = os.path.join(self.graph_dir_path, f"{prefix}{gcConst.EDGES_FILE_PREFIX}_{key}.csv")
             with open(edges_path, "w") as out_file:
-                writer = csv.writer(out_file, delimiter=file_sep, lineterminator="\n")
+                writer = csv.writer(out_file, delimiter=self.file_sep, lineterminator="\n")
                 for edge in value:
-                    if qscore:
+                    if self.print_qscore:
                         writer.writerow(list(edge))
                     else:
                         writer.writerow(edge.to_sub_rel_obj_list())

--- a/src/openbiolink/graph_creation/graph_writer/pickle_writer.py
+++ b/src/openbiolink/graph_creation/graph_writer/pickle_writer.py
@@ -16,10 +16,10 @@ __all__ = [
 
 
 class GraphPickleWriter(GraphWriter):
-    def write(self, *, nodes_dic, tp_edges: Mapping[str, Edge], tp_namespaces, tn_nodes, tn_edges, tn_namespaces):
+    def write(self, *, tp_nodes, tp_edges: Mapping[str, Edge], tp_namespaces, tn_nodes, tn_edges, tn_namespaces):
         """Write the graph as pickles."""
         with open(os.path.join(self.graph_dir_path, "tp_nodes.pkl"), "wb") as file:
-            pickle.dump(nodes_dic, file, protocol=pickle.HIGHEST_PROTOCOL)
+            pickle.dump(tp_nodes, file, protocol=pickle.HIGHEST_PROTOCOL)
         with open(os.path.join(self.graph_dir_path, "tp_edges.pkl"), "wb") as file:
             pickle.dump(tp_edges, file, protocol=pickle.HIGHEST_PROTOCOL)
         with open(os.path.join(self.graph_dir_path, "tp_namespaces.pkl"), "wb") as file:

--- a/src/openbiolink/graph_creation/graph_writer/pickle_writer.py
+++ b/src/openbiolink/graph_creation/graph_writer/pickle_writer.py
@@ -1,0 +1,32 @@
+"""A utility for outputting graphs as pickle files.
+
+To test, run ``openbiolink generate --no-download --no-input --output-format pickle --qual hq``.
+"""
+
+import os
+import pickle
+from typing import Mapping
+
+from openbiolink.edge import Edge
+from openbiolink.graph_creation.graph_writer.base import GraphWriter
+
+__all__ = [
+    'GraphPickleWriter',
+]
+
+
+class GraphPickleWriter(GraphWriter):
+    def write(self, *, nodes_dic, tp_edges: Mapping[str, Edge], tp_namespaces, tn_nodes, tn_edges, tn_namespaces):
+        """Write the graph as pickles."""
+        with open(os.path.join(self.graph_dir_path, "tp_nodes.pkl"), "wb") as file:
+            pickle.dump(nodes_dic, file, protocol=pickle.HIGHEST_PROTOCOL)
+        with open(os.path.join(self.graph_dir_path, "tp_edges.pkl"), "wb") as file:
+            pickle.dump(tp_edges, file, protocol=pickle.HIGHEST_PROTOCOL)
+        with open(os.path.join(self.graph_dir_path, "tp_namespaces.pkl"), "wb") as file:
+            pickle.dump(tp_namespaces, file, protocol=pickle.HIGHEST_PROTOCOL)
+        with open(os.path.join(self.graph_dir_path, "tn_nodes.pkl"), "wb") as file:
+            pickle.dump(tn_nodes, file, protocol=pickle.HIGHEST_PROTOCOL)
+        with open(os.path.join(self.graph_dir_path, "tn_edges.pkl"), "wb") as file:
+            pickle.dump(tn_edges, file, protocol=pickle.HIGHEST_PROTOCOL)
+        with open(os.path.join(self.graph_dir_path, "tn_namespaces.pkl"), "wb") as file:
+            pickle.dump(tn_namespaces, file, protocol=pickle.HIGHEST_PROTOCOL)

--- a/src/openbiolink/graph_creation/graph_writer/pickle_writer.py
+++ b/src/openbiolink/graph_creation/graph_writer/pickle_writer.py
@@ -11,7 +11,7 @@ from openbiolink.edge import Edge
 from openbiolink.graph_creation.graph_writer.base import GraphWriter
 
 __all__ = [
-    'GraphPickleWriter',
+    "GraphPickleWriter",
 ]
 
 

--- a/src/openbiolink/graph_creation/types/qualityType.py
+++ b/src/openbiolink/graph_creation/types/qualityType.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import Optional
 
 
 class QualityType(Enum):
@@ -7,12 +8,14 @@ class QualityType(Enum):
     LQ = 2
 
     @classmethod
-    def get_quality_type(cls, qual: str) -> "QualityType":
-        if qual == "hq":
+    def get_quality_type(cls, qual: Optional[str]) -> Optional["QualityType"]:
+        if qual is None:
+            return None
+        qual = qual.lower()
+        if qual in {"hq", "high", "h"}:
             return cls.HQ
-        elif qual == "mq":
+        if qual == {"mq", "medium", "m"}:
             return cls.MQ
-        elif qual == "lq":
+        if qual == {"lq", "low", "l"}:
             return cls.LQ
-        else:
-            raise ValueError(f"Invalid QualityType: {qual}")
+        raise ValueError(f"Invalid QualityType: {qual}")


### PR DESCRIPTION
As I started working on #29, I found that it was pretty tricky to navigate through the graph writer classes. It wasn't obvious how data was being encapsulated, which functions were static, and how data was passed between them. This PR starts to reorganize some of that code so it will be amenable to extension and inclusion of additional writers. It does the following:

- Abstract shared code between RDF and TSV writers into base class (OpenBioLinkGraphWriter)
- Abstract one level further (GraphWriter) to allow other types of writers that don't make the same kinds of assumptions (preparing for )
- Reorganize which information is kept as instance information as well as how it's passed between functions. Also rename some variables for brevity and clarity
- Implementation of the PickleWriter, which just dumps the node and edge dicts.